### PR TITLE
chore: Restore Win-x86 Assets Before MSIX Packaging

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -92,6 +92,11 @@ jobs:
       shell: pwsh
       run: ./scripts/run-tests.ps1 -Configuration Release -Verbosity normal
 
+    # Desktop Bridge packaging restores/publishes the app as win-x86 internally.
+    # Keep this even when package platform is AnyCPU, otherwise NETSDK1047 occurs.
+    - name: Restore app assets for MSIX runtime
+      run: dotnet restore ${{ env.APP_PROJECT }} --runtime win-x86
+
     - name: Build MSIX
       shell: pwsh
       run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -78,6 +78,11 @@ jobs:
       shell: pwsh
       run: ./scripts/run-tests.ps1 -Configuration Release -Verbosity normal
 
+    # Desktop Bridge packaging restores/publishes the app as win-x86 internally.
+    # Keep this even when package platform is AnyCPU, otherwise NETSDK1047 occurs.
+    - name: Restore app assets for MSIX runtime
+      run: dotnet restore ${{ env.APP_PROJECT }} --runtime win-x86
+
     - name: Build MSIX
       shell: pwsh
       run: |

--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -93,6 +93,11 @@ jobs:
       shell: pwsh
       run: ./scripts/run-tests.ps1 -Configuration Release -Verbosity normal
 
+    # Desktop Bridge packaging restores/publishes the app as win-x86 internally.
+    # Keep this even when package platform is AnyCPU, otherwise NETSDK1047 occurs.
+    - name: Restore app assets for MSIX runtime
+      run: dotnet restore ${{ env.APP_PROJECT }} --runtime win-x86
+
     - name: Build Store Package
       shell: pwsh
       run: |


### PR DESCRIPTION
Add the win-x86 restore step back to Dev/Release/Store workflows.

Desktop Bridge packaging publishes the app with win-x86 internally, so missing RID assets causes NETSDK1047.