### PR TITLE
chore: adopt release-line floating tags and pinned store refs

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -245,7 +245,10 @@ jobs:
         }
 
         foreach ($asset in $assets) {
-          gh release delete-asset $tag $asset --repo $repo --yes
+          gh release delete-asset $tag $asset --repo $repo --yes *> $null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to delete old asset '$asset' from release '$tag'."
+          }
           Write-Host "Deleted old asset: $asset"
         }
 
@@ -292,4 +295,11 @@ jobs:
         | Provenance | `GitHub Artifact Attestation` |
         | Artifact | `dev-package-${{ steps.version.outputs.MSIX_VERSION }}` |
         '@ >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Move dev-latest tag to current commit
+      if: ${{ success() }}
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: ./scripts/update-floating-tag.ps1 -Repo "${{ github.repository }}" -Tag "dev-latest" -Sha "${{ github.sha }}"
 

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -21,6 +21,10 @@ concurrency:
   group: prepare-patch-release
   cancel-in-progress: false
 
+env:
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+
 jobs:
   prepare:
     runs-on: windows-latest
@@ -34,6 +38,18 @@ jobs:
           throw "Invalid release branch format: $branch (expected release/X.Y)"
         }
 
+    - name: Verify target release branch exists
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $branch = "${{ inputs.release_branch }}"
+        $encodedBranch = [Uri]::EscapeDataString($branch)
+        gh api "repos/${{ github.repository }}/branches/$encodedBranch" *> $null
+        if ($LASTEXITCODE -ne 0) {
+          throw "Target release branch does not exist: $branch"
+        }
+
     - name: Checkout release branch
       uses: actions/checkout@v4
       with:
@@ -43,8 +59,8 @@ jobs:
     - name: Configure git author
       shell: pwsh
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "${{ env.GIT_AUTHOR_NAME }}"
+        git config user.email "${{ env.GIT_AUTHOR_EMAIL }}"
 
     - name: Create patch init branch
       id: patch

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -21,6 +21,10 @@ concurrency:
   group: prepare-release-branch
   cancel-in-progress: false
 
+env:
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+
 jobs:
   prepare:
     runs-on: windows-latest
@@ -35,8 +39,8 @@ jobs:
     - name: Configure git author
       shell: pwsh
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "${{ env.GIT_AUTHOR_NAME }}"
+        git config user.email "${{ env.GIT_AUTHOR_EMAIL }}"
 
     - name: Create release and main bump branches
       shell: pwsh

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -57,6 +57,7 @@ jobs:
       id: version
       shell: pwsh
       run: |
+        $branch = "${{ github.ref_name }}"
         [xml]$props = Get-Content Directory.Build.props
         $version = $props.Project.PropertyGroup.Version
         $match = [regex]::Match($version, '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$')
@@ -64,7 +65,14 @@ jobs:
           Write-Error "Invalid version format in Directory.Build.props (expected X.Y.Z): $version"
           exit 1
         }
+        $branchMatch = [regex]::Match($branch, '^release/(?<major>\d+)\.(?<minor>\d+)$')
+        if (-not $branchMatch.Success) {
+          Write-Error "Invalid release branch format for channel tag resolution: $branch"
+          exit 1
+        }
         $coreVersion = "$($match.Groups['major'].Value).$($match.Groups['minor'].Value).$($match.Groups['patch'].Value)"
+        $releaseLine = "$($branchMatch.Groups['major'].Value).$($branchMatch.Groups['minor'].Value)"
+        $releaseChannelTag = "release-$releaseLine-latest"
         $shortSha = "${{ github.sha }}".Substring(0, 7)
         $segments = @(
           [int]$match.Groups['major'].Value,
@@ -87,11 +95,13 @@ jobs:
         echo "FILE_VERSION=$fileVersion" >> $env:GITHUB_OUTPUT
         echo "INFORMATIONAL_VERSION=$informationalVersion" >> $env:GITHUB_OUTPUT
         echo "MSIX_VERSION=$msixVersion" >> $env:GITHUB_OUTPUT
+        echo "RELEASE_CHANNEL_TAG=$releaseChannelTag" >> $env:GITHUB_OUTPUT
         echo "Version: $version"
         echo "AssemblyVersion: $assemblyVersion"
         echo "FileVersion: $fileVersion"
         echo "InformationalVersion: $informationalVersion"
         echo "MSIX version: $msixVersion"
+        echo "Release channel tag: $releaseChannelTag"
 
     - name: Validate version
       shell: pwsh
@@ -224,7 +234,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        $tag = "release-latest"
+        $tag = "${{ steps.version.outputs.RELEASE_CHANNEL_TAG }}"
         $repo = "${{ github.repository }}"
 
         $assetNames = gh release view $tag --repo $repo --json assets --jq '.assets[].name' 2>$null
@@ -240,15 +250,18 @@ jobs:
         }
 
         foreach ($asset in $assets) {
-          gh release delete-asset $tag $asset --repo $repo --yes
+          gh release delete-asset $tag $asset --repo $repo --yes *> $null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to delete old asset '$asset' from release '$tag'."
+          }
           Write-Host "Deleted old asset: $asset"
         }
 
     - name: Create Release Channel
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
-        tag_name: release-latest
-        name: Release (Latest)
+        tag_name: ${{ steps.version.outputs.RELEASE_CHANNEL_TAG }}
+        name: Release Candidate (${{ github.ref_name }})
         body: |
           ## Release Build (Unsigned)
 
@@ -290,4 +303,11 @@ jobs:
         | Branch | `${{ github.ref_name }}` |
         | Build | [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
         '@ >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Move release channel tag to current commit
+      if: ${{ success() }}
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: ./scripts/update-floating-tag.ps1 -Repo "${{ github.repository }}" -Tag "${{ steps.version.outputs.RELEASE_CHANNEL_TAG }}" -Sha "${{ github.sha }}"
 

--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version to publish (e.g., 1.0.0)'
         required: true
         type: string
+      source_ref:
+        description: 'Optional pinned git ref (tag/SHA/refs/*). Empty = tip of resolved release branch'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -34,6 +38,20 @@ jobs:
         echo "BRANCH=$branch" >> $env:GITHUB_OUTPUT
         echo "Resolved branch: $branch"
 
+    - name: Resolve checkout ref
+      id: checkout
+      shell: pwsh
+      run: |
+        $sourceRef = "${{ inputs.source_ref }}".Trim()
+        $defaultRef = "${{ steps.release.outputs.BRANCH }}"
+        $checkoutRef = if ([string]::IsNullOrWhiteSpace($sourceRef)) { $defaultRef } else { $sourceRef }
+        $isPinned = if ([string]::IsNullOrWhiteSpace($sourceRef)) { "false" } else { "true" }
+
+        echo "REF=$checkoutRef" >> $env:GITHUB_OUTPUT
+        echo "PINNED=$isPinned" >> $env:GITHUB_OUTPUT
+        echo "Resolved checkout ref: $checkoutRef"
+        echo "Pinned mode: $isPinned"
+
     - name: Verify branch exists
       shell: pwsh
       run: |
@@ -51,7 +69,36 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ steps.release.outputs.BRANCH }}
+        ref: ${{ steps.checkout.outputs.REF }}
+        fetch-depth: 0
+
+    - name: Validate pinned source ref is in target release branch
+      if: ${{ steps.checkout.outputs.PINNED == 'true' }}
+      shell: pwsh
+      run: |
+        $branch = "${{ steps.release.outputs.BRANCH }}"
+        $ref = "${{ steps.checkout.outputs.REF }}"
+
+        git fetch --no-tags origin "$branch"
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to fetch origin/$branch for ancestry verification."
+          exit 1
+        }
+
+        git merge-base --is-ancestor HEAD "origin/$branch"
+        $mergeBaseExit = $LASTEXITCODE
+        if ($mergeBaseExit -eq 1) {
+          Write-Error "Pinned ref '$ref' is not contained in origin/$branch"
+          exit 1
+        }
+        if ($mergeBaseExit -ne 0) {
+          Write-Error "Failed to verify whether pinned ref '$ref' is contained in origin/$branch"
+          exit 1
+        }
+
+        $head = (git rev-parse HEAD).Trim()
+        $branchHead = (git rev-parse "origin/$branch").Trim()
+        echo "Pinned ref verified: $ref -> $head (ancestor of origin/$branch @ $branchHead)"
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -100,6 +147,11 @@ jobs:
         }
 
         $coreVersion = "$($match.Groups['major'].Value).$($match.Groups['minor'].Value).$($match.Groups['patch'].Value)"
+        $commitSha = (git rev-parse HEAD).Trim()
+        if (-not $commitSha -or $commitSha.Length -ne 40) {
+          Write-Error "Failed to resolve commit SHA from checked-out source."
+          exit 1
+        }
         $shortSha = (git rev-parse --short=7 HEAD).Trim()
         if (-not $shortSha -or $shortSha.Length -ne 7) {
           Write-Error "Failed to resolve short SHA from checked-out commit."
@@ -113,6 +165,7 @@ jobs:
         echo "ASSEMBLY_VERSION=$assemblyVersion" >> $env:GITHUB_OUTPUT
         echo "FILE_VERSION=$fileVersion" >> $env:GITHUB_OUTPUT
         echo "INFORMATIONAL_VERSION=$informationalVersion" >> $env:GITHUB_OUTPUT
+        echo "COMMIT_SHA=$commitSha" >> $env:GITHUB_OUTPUT
         echo "Version: $version"
         echo "AssemblyVersion: $assemblyVersion"
         echo "FileVersion: $fileVersion"
@@ -194,6 +247,8 @@ jobs:
         |------|-------|
         | **Version** | ``${{ inputs.version }}`` |
         | **Branch** | ``${{ steps.release.outputs.BRANCH }}`` |
+        | **Checkout Ref** | ``${{ steps.checkout.outputs.REF }}`` |
+        | **Commit SHA** | ``${{ steps.version.outputs.COMMIT_SHA }}`` |
         | **InformationalVersion** | ``${{ steps.version.outputs.INFORMATIONAL_VERSION }}`` |
         | **Package** | ``.msixupload`` |
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ClipSave は、コピーした内容を `Ctrl+Shift+V` で即保存する軽量�
 ## インストール
 
 - **Stable（一般ユーザー向け）**: Microsoft Store（公開後）
-- **Dev/Release artifacts**: `Releases`（`dev-latest` / `release-latest`）の `*.msixbundle` は未署名の検証アーティファクトです。インストールする場合は、[検証アーティファクト導入手順](docs/ops/ArtifactInstallation.md) を参照してください
+- **Dev/Release artifacts**: `Releases`（`dev-latest` / `release-X.Y-latest`）の `*.msixbundle` は未署名の検証アーティファクトです。インストールする場合は、[検証アーティファクト導入手順](docs/ops/ArtifactInstallation.md) を参照してください
 - **開発・検証（推奨）**: ソースから実行
 
 ```bash

--- a/docs/ops/ArtifactInstallation.md
+++ b/docs/ops/ArtifactInstallation.md
@@ -1,12 +1,13 @@
 # 検証アーティファクト導入手順
 
-`dev-latest` / `release-latest` の `*.msixbundle` は、開発者向けの未署名成果物です。
+`dev-latest` / `release-X.Y-latest` の `*.msixbundle` は、開発者向けの未署名成果物です。
 本番配布（一般ユーザー向け）は Store チャネルを利用してください。
 
 ## 対象
 
 - Dev チャネル: `dev-latest` / `dev-package-*`
-- Release チャネル: `release-latest` / `release-package-*`
+- Release チャネル: `release-X.Y-latest` / `release-package-*`
+- `release/X.Y` ブランチの最新候補タグは `release-X.Y-latest`（例: `release/1.3` -> `release-1.3-latest`）
 
 ## 事前準備
 

--- a/docs/ops/Versioning.md
+++ b/docs/ops/Versioning.md
@@ -63,7 +63,11 @@ ClipSave の版数規約と判定ルールを定義します。
 |------|----------|--------|
 | CI/CD | `InformationalVersion` + 実行ブランチ | `-` サフィックスなし、かつ `release/X.Y` 実行 |
 | DLL 確認 | `FileVersion` | 4 番目（BUILD）が `0` なら Release |
-| 配布物 | 配布チャネル | `release-latest` または `release-build.yml` 由来成果物を Release とみなす |
+| 配布物 | 配布チャネル | `release-X.Y-latest` または `release-build.yml` 由来成果物を Release とみなす |
+
+補足:
+
+- `dev-latest` と `release-X.Y-latest` は固定版タグではなく移動タグ（floating tag）として運用し、各 workflow 成功時に実行コミットへ更新する。
 
 ## 検証ルール（`assert-version-policy.ps1`）
 

--- a/scripts/store-checklist.ps1
+++ b/scripts/store-checklist.ps1
@@ -166,6 +166,7 @@ try {
 
     $checklist = @(
         "Release package artifact (release-package-$version, unsigned) reviewed for at least 24 hours",
+        "Selected source ref for Store Publish recorded (release-X.Y-latest tag or commit SHA)",
         "No critical bugs reported",
         "Partner Center app description updated (Japanese)",
         "Partner Center app description updated (English)",

--- a/scripts/update-floating-tag.ps1
+++ b/scripts/update-floating-tag.ps1
@@ -1,0 +1,72 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Create or move a floating tag to a specific commit.
+
+.DESCRIPTION
+    Updates `refs/tags/<tag>` in GitHub using `gh api`.
+    If the tag does not exist, it creates it.
+
+.PARAMETER Repo
+    Repository in owner/name format (example: tnagata012/ClipSave).
+
+.PARAMETER Tag
+    Tag name to move (example: dev-latest, release-1.3-latest).
+
+.PARAMETER Sha
+    Target full commit SHA (40 hex characters).
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repo,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Tag,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string]$Sha
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    Write-Host "`n[ERROR] $Message" -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Fail "'gh' command not found. Install GitHub CLI first."
+}
+
+$targetSha = $Sha.Trim().ToLowerInvariant()
+$ref = "tags/$Tag"
+$updated = $false
+
+# Try update first. If tag does not exist, create it.
+gh api --method PATCH "repos/$Repo/git/refs/$ref" -f sha="$targetSha" -F force=true *> $null
+if ($LASTEXITCODE -eq 0) {
+    $updated = $true
+} else {
+    gh api --method POST "repos/$Repo/git/refs" -f ref="refs/$ref" -f sha="$targetSha" *> $null
+    if ($LASTEXITCODE -eq 0) {
+        $updated = $true
+    }
+}
+
+if (-not $updated) {
+    Fail "Failed to create or update tag '$Tag' in '$Repo'."
+}
+
+$resolvedSha = gh api "repos/$Repo/git/ref/$ref" --jq '.object.sha' 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($resolvedSha)) {
+    Fail "Failed to resolve updated tag reference: $Tag"
+}
+
+$resolvedSha = $resolvedSha.Trim().ToLowerInvariant()
+if ($resolvedSha -ne $targetSha) {
+    Fail "Tag update verification failed. Expected: $targetSha, Actual: $resolvedSha"
+}
+
+Write-Host "Floating tag updated: $Tag -> $resolvedSha"


### PR DESCRIPTION
## Summary
- adopt release-line floating tags (elease-X.Y-latest) in Release Build and docs
- add scripts/update-floating-tag.ps1 and call it from dev/release workflows
- add optional source_ref to Store Publish with ancestry validation
- align prepare workflows git author to triggering actor and add release branch existence guard

## Notes
- no runtime app code changes (CI/docs/ops scripts only)