### PR TITLE
ci: update attest-build-provenance to v3.2.0

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -217,7 +217,7 @@ jobs:
         retention-days: 14
 
     - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
       with:
         subject-path: |
           output/**/*.msixbundle

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -222,7 +222,7 @@ jobs:
         retention-days: 30
 
     - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
       with:
         subject-path: |
           output/**/*.msixbundle


### PR DESCRIPTION
## Summary

- Updated `actions/attest-build-provenance` from v3.0.0 (`43d14bc`) to v3.2.0 (`96278af`)
- Fixed both `dev-build.yml` and `release-build.yml`

## Background

In the most recent workflow failure, the `Generate artifact attestation` step failed with `InternalError: error fetching tlog entry - (404) Not Found`.

In v3.1.0, the internal library `@actions/attest` was updated to v2.0.0, improving error handling. In v3.2.0, `@actions/core` has also been updated to v2.0.1.