### PR TITLE
fix: remove temporary store cert setting for CI unsigned builds

### DIFF
--- a/src/ClipSave.Package/ClipSave.Package.wapproj
+++ b/src/ClipSave.Package/ClipSave.Package.wapproj
@@ -64,7 +64,6 @@
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundlePlatforms>neutral</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AppxBundle>Always</AppxBundle>


### PR DESCRIPTION
## Summary
- Removed `GenerateTemporaryStoreCertificate` from `src/ClipSave.Package/ClipSave.Package.wapproj`.
- Kept Store association (`Package.StoreAssociation.xml`) as-is; only the CI-conflicting temp certificate setting was reverted.
- Confirmed local quality gates after the fix.

## Why
- GitHub Actions run `22534721360` failed in the unsigned MSIX step with:
  `error MSB4044: RemoveDisposableSigningCertificate ... required parameter "CertificateThumbprint"`.
- `GenerateTemporaryStoreCertificate=True` triggers disposable cert cleanup logic, which conflicts with CI unsigned packaging (`/p:AppxPackageSigningEnabled=false`).

## Checklist
### Change Type (choose one)
- [ ] Docs/CI/repo config only.
- [x] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes.
