### PR TITLE
Add Pages deployment workflow and website CI shortcuts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,55 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Guard main branch
+      shell: pwsh
+      run: |
+        $branch = "${{ github.ref_name }}"
+        if ($branch -ne "main") {
+          Write-Error "Deploy Pages can run only on 'main'. Current ref: $branch"
+          exit 1
+        }
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure Pages
+      uses: actions/configure-pages@v5
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+      - 'site/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: pr-check-${{ github.head_ref }}
@@ -24,12 +25,62 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Lint GitHub Actions workflows
+      uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
+    - name: Detect website-only changes
+      id: changes
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const websiteOnlyPatterns = [
+            /^site\//,
+            /^\.github\/workflows\/deploy-pages\.yml$/,
+            /^docs\/presentation\/LandingPage\.md$/,
+          ];
+
+          const files = await github.paginate(github.rest.pulls.listFiles, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+            per_page: 100,
+          });
+
+          const changedFiles = files.flatMap((file) => {
+            const paths = [file.filename];
+            if (file.status === "renamed" && file.previous_filename) {
+              paths.push(file.previous_filename);
+            }
+            return paths;
+          });
+          const changedFileLog = files.map((file) =>
+            file.status === "renamed" && file.previous_filename
+              ? `${file.previous_filename} -> ${file.filename}`
+              : file.filename
+          );
+          const websiteOnly =
+            changedFiles.length > 0 &&
+            changedFiles.every((filename) =>
+              websiteOnlyPatterns.some((pattern) => pattern.test(filename))
+            );
+
+          core.info(`Changed files:\n${changedFileLog.join("\n")}`);
+          core.setOutput("website_only", String(websiteOnly));
+
+    - name: Website-only PR shortcut
+      if: steps.changes.outputs.website_only == 'true'
+      shell: pwsh
+      run: |
+        Write-Host "Website-only PR detected. Skipping restore/build/test pipeline."
+
     - name: Setup .NET
+      if: steps.changes.outputs.website_only != 'true'
       uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
 
     - name: Cache NuGet packages
+      if: steps.changes.outputs.website_only != 'true'
       uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
@@ -37,24 +88,29 @@ jobs:
         restore-keys: ${{ runner.os }}-nuget-
 
     - name: Restore
+      if: steps.changes.outputs.website_only != 'true'
       run: dotnet restore ${{ env.SOLUTION_FILE }}
 
     - name: Security checks
+      if: steps.changes.outputs.website_only != 'true'
       shell: pwsh
       run: ./scripts/run-security-checks.ps1 -Configuration Debug -NoRestore
 
     - name: Build app
+      if: steps.changes.outputs.website_only != 'true'
       run: dotnet build ${{ env.APP_PROJECT }} --configuration Debug --no-restore
 
     - name: Localization resource guard
+      if: steps.changes.outputs.website_only != 'true'
       run: dotnet test tests/ClipSave.UnitTests/ClipSave.UnitTests.csproj --configuration Debug --filter "FullyQualifiedName~LocalizationResourceCompletenessTests"
 
     - name: Test
+      if: steps.changes.outputs.website_only != 'true'
       shell: pwsh
       run: ./scripts/run-tests.ps1 -Configuration Debug -Verbosity normal -EmitTrx -ResultsDirectory "${{ github.workspace }}/TestResults"
 
     - name: Upload test results
-      if: always()
+      if: always() && steps.changes.outputs.website_only != 'true'
       uses: actions/upload-artifact@v4
       with:
         name: pr-test-results
@@ -63,6 +119,7 @@ jobs:
         retention-days: 14
 
     - name: SPEC traceability guard
+      if: steps.changes.outputs.website_only != 'true'
       shell: pwsh
       run: ./scripts/check-spec-coverage.ps1
 

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -3,6 +3,10 @@ name: RC Build
 on:
   push:
     branches: ['release/*']
+    paths-ignore:
+      - 'site/**'
+      - '.github/workflows/deploy-pages.yml'
+      - 'docs/presentation/LandingPage.md'
   workflow_dispatch:
 
 permissions:

--- a/docs/dev/TestingStrategy.md
+++ b/docs/dev/TestingStrategy.md
@@ -226,11 +226,11 @@ dotnet test tests/ClipSave.UiTests/ClipSave.UiTests.csproj --filter "Category=UI
 
 ## CI 連携
 
-GitHub Actions では、すべてのビルド系ワークフローでテストを実行する。
+GitHub Actions では、アプリ本体をビルドする workflow でテストを実行する。`pr-check.yml` は website-only PR（`site/**`、`.github/workflows/deploy-pages.yml`、`docs/presentation/LandingPage.md` のみ変更）のとき、workflow lint と version validation を維持したまま restore / build / test を skip する。
 
 | Workflow            | 起動条件                       | テスト手順                                                                 |
 | ------------------- | -------------------------- | --------------------------------------------------------------------- |
-| `pr-check.yml`      | PR to `main` / `release/*` | `run-tests.ps1`（Debug） + `LocalizationResourceCompletenessTests` 先行実行 + `check-spec-coverage.ps1` |
+| `pr-check.yml`      | PR to `main` / `release/*` | `run-tests.ps1`（Debug） + `LocalizationResourceCompletenessTests` 先行実行 + `check-spec-coverage.ps1`（website-only PR では skip） |
 | `dev-build.yml`     | Push to `main`             | `run-tests.ps1`（Release）                                              |
 | `rc-build.yml`      | Push to `release/*`        | `run-tests.ps1`（Release）                                              |
 | `release-finalize.yml` | Tag push / Manual dispatch | `run-tests.ps1`（Release）                                              |

--- a/docs/ops/Deployment.md
+++ b/docs/ops/Deployment.md
@@ -23,10 +23,11 @@ ClipSave の CI/CD と配布実行手順（Runbook）を定義します。
 | ワークフロー | トリガー | 用途 | 主な生成物 |
 |-------------|---------|------|-----------|
 | [pr-check.yml](../../.github/workflows/pr-check.yml) | PR（`main`, `release/*`） | 品質ゲート | `TestResults/**/*.trx` |
+| [deploy-pages.yml](../../.github/workflows/deploy-pages.yml) | `main` push（`site/**`, `.github/workflows/deploy-pages.yml`） / 手動 | GitHub Pages 公開 | GitHub Pages site artifact |
 | [prepare-release-branch.yml](../../.github/workflows/prepare-release-branch.yml) | 手動（`X.Y.0`） | `release/X.Y` 作成 + main 側 bump ブランチ作成 | `release/X.Y`, `chore/bump-main-to-*` |
 | [prepare-patch-release.yml](../../.github/workflows/prepare-patch-release.yml) | 手動（`release/X.Y`） | patch init ブランチ作成 | `chore/release-X.Y.(Z+1)-init` |
-| [dev-build.yml](../../.github/workflows/dev-build.yml) | `main` push（`docs/**`, `*.md` のみ変更時は除く） / 手動 | 開発成果物生成（未署名） | `dev-package-*`, `dev-latest`, `SHA256SUMS.txt`, `GitHub Artifact Attestation` |
-| [rc-build.yml](../../.github/workflows/rc-build.yml) | `release/*` push / 手動 | 公開候補生成（未署名） | `rc-package-*`, `rc-X.Y-latest`, `SHA256SUMS.txt`, `GitHub Artifact Attestation` |
+| [dev-build.yml](../../.github/workflows/dev-build.yml) | `main` push（`docs/**`, `*.md`, `site/**`, `.github/workflows/deploy-pages.yml` のみ変更時は除く） / 手動 | 開発成果物生成（未署名） | `dev-package-*`, `dev-latest`, `SHA256SUMS.txt`, `GitHub Artifact Attestation` |
+| [rc-build.yml](../../.github/workflows/rc-build.yml) | `release/*` push（`site/**`, `.github/workflows/deploy-pages.yml`, `docs/presentation/LandingPage.md` のみ変更時は除く） / 手動 | 公開候補生成（未署名） | `rc-package-*`, `rc-X.Y-latest`, `SHA256SUMS.txt`, `GitHub Artifact Attestation` |
 | [release-finalize.yml](../../.github/workflows/release-finalize.yml) | `X.Y.Z` タグ push / 手動 | 確定版アーカイブ生成（未署名）、GitHub Release メタデータ調整、任意の Store package 生成 | `release-archive-*`, GitHub Release `X.Y.Z`, `SHA256SUMS.txt`, `GitHub Artifact Attestation`, 任意で `store-package-*` |
 
 補足:
@@ -34,6 +35,7 @@ ClipSave の CI/CD と配布実行手順（Runbook）を定義します。
 - 配布対象は `*.msixbundle`（未署名）、Store 提出対象は `.msixupload`。
 - Dev/RC 配布では `*.msixbundle` と `SHA256SUMS.txt` をセットで公開し、GitHub Artifact Attestation を記録する。
 - `.NET` SDK の解決はリポジトリ直下の `global.json` を単一の正本とし、workflow の `actions/setup-dotnet` は `global-json-file: global.json` を参照する。
+- `pr-check.yml` は workflow lint を常時実行し、website-only PR（`site/**`, `.github/workflows/deploy-pages.yml`, `docs/presentation/LandingPage.md` のみ変更）のときは restore / build / test を skip する。
 - `dev-latest` と `rc-X.Y-latest` は確定タグではなく移動タグ（floating tag）として運用し、各 workflow 成功時に実行コミットへ更新する。
 - `release/X.Y` ブランチの配布タグは `rc-X.Y-latest`（例: `release/1.3` -> `rc-1.3-latest`）。
 - `rc-X.Y-latest` の GitHub Release は候補版として常に `prerelease` 表示にする。

--- a/docs/presentation/LandingPage.md
+++ b/docs/presentation/LandingPage.md
@@ -28,6 +28,7 @@ ClipSave のランディングページ（`site/`）の更新方針と確認手�
 2. `site/` 配下を変更
 3. ローカル確認を実施
 4. PR 作成（文言修正とデザイン変更は分離）
+5. `main` へマージ後、GitHub Pages への自動公開を確認
 
 ## ローカル確認手順
 
@@ -37,6 +38,15 @@ python -m http.server 4173 --directory site
 
 - ブラウザで `http://localhost:4173` を開く
 - 確認後は `Ctrl + C` でサーバー停止
+
+## 公開運用
+
+- 公開 URL は `https://tnagata012.github.io/ClipSave/`
+- GitHub Pages の公開元は `GitHub Actions`
+- `main` に対する `site/**` または `.github/workflows/deploy-pages.yml` の変更は `Deploy Pages` workflow（`.github/workflows/deploy-pages.yml`）で自動公開する
+- `Deploy Pages` の手動実行は再公開用途に限定し、`main` ブランチからのみ実行する
+- `site/**` と `docs/presentation/LandingPage.md` だけの変更ではアプリ本体の `Dev Build` / `RC Build` は起動しない
+- `PR Check` は必須チェックを維持したまま、website-only PR のときは restore / build / test を skip する
 
 ## 運用ルール
 
@@ -66,6 +76,7 @@ python -m http.server 4173 --directory site
 ### 変更単位
 
 - 1つの PR で目的を混在させない
+- サイト更新は原則としてアプリ実装変更と分離する
 - 推奨分割:
   - 文言修正 PR
   - デザイン修正 PR


### PR DESCRIPTION
## Summary
- add a `Deploy Pages` workflow to publish `site/` updates from `main`
- skip app restore/build/test for website-only PRs while keeping workflow lint and version validation in `PR Check`
- update presentation and ops/testing docs to match the new deployment and CI behavior

## Why
- landing page updates should publish automatically without triggering the full app build pipelines
- workflow changes for Pages deployment should still be validated before merge
- the runbooks need to describe the new trigger and shortcut behavior accurately

## Checklist
### Change Type (choose one)
- [x] Docs/CI/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

Quality note: local app tests were not run because this change only affects GitHub Actions workflows and documentation. I verified the staged diff with `git diff --check --cached`.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes.