### PR TITLE
docs: translate README to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ dotnet run --project src/ClipSave/ClipSave.csproj --configuration Release
 
 ## Documentation
 
-Some documents, including most files under [`docs/`](docs/) and a few top-level documents such as [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), are written in Japanese.
+Project documentation is written in Japanese.
 
 - [Usage Guide](docs/UsageGuide.md) - Basic operations and settings
 - [Product Concept](docs/ProductConcept.md) - Vision and design principles


### PR DESCRIPTION
## Summary
- translate the README into English
- clarify that some documents, including most files under `docs/` and top-level files such as `CODE_OF_CONDUCT.md`, remain in Japanese

## Why
- make the repository landing page accessible to English readers without implying all project documents are translated

## Checklist
### Change Type (choose one)
- [x] Docs/CI/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

Tests were not run because this is a documentation-only change.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes.