### PR TITLE
chore: simplify Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,12 +5,10 @@ on:
     branches: [main]
     paths:
       - 'site/**'
-      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
-  deployments: write
   pages: write
   id-token: write
 
@@ -56,76 +54,3 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
-
-    - name: Clean up stale Pages deployments
-      shell: pwsh
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        $repo = "${{ github.repository }}"
-        $environment = "github-pages"
-        $maxAttempts = 6
-        $sleepSeconds = 10
-
-        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-          $deploymentsJson = gh api "repos/$repo/deployments?environment=$environment&per_page=100"
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to list deployments for environment '$environment'."
-          }
-
-          $deployments = @($deploymentsJson | ConvertFrom-Json)
-          if ($deployments.Count -le 1) {
-            Write-Host "No stale Pages deployments found."
-            break
-          }
-
-          $orderedDeployments = @(
-            $deployments | Sort-Object { [DateTimeOffset]::Parse($_.created_at) } -Descending
-          )
-          $staleDeployments = @($orderedDeployments | Select-Object -Skip 1)
-          $pendingDeploymentStates = New-Object System.Collections.Generic.List[string]
-          $deletedDeployments = 0
-
-          foreach ($staleDeployment in $staleDeployments) {
-            $deploymentId = [string]$staleDeployment.id
-            $statusesJson = gh api "repos/$repo/deployments/$deploymentId/statuses?per_page=1"
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to read statuses for deployment '$deploymentId'."
-            }
-
-            $statuses = @($statusesJson | ConvertFrom-Json)
-            $latestState = ""
-            if ($statuses.Count -gt 0 -and $null -ne $statuses[0].state) {
-              $latestState = [string]$statuses[0].state
-            }
-
-            if ($latestState -eq "inactive") {
-              gh api --method DELETE "repos/$repo/deployments/$deploymentId" *> $null
-              if ($LASTEXITCODE -ne 0) {
-                throw "Failed to delete inactive deployment '$deploymentId'."
-              }
-
-              $deletedDeployments++
-              Write-Host "Deleted inactive Pages deployment: $deploymentId"
-              continue
-            }
-
-            $pendingDeploymentStates.Add("${deploymentId}:${latestState}")
-            Write-Host "Keeping deployment $deploymentId until it becomes inactive (latest state: '$latestState')."
-          }
-
-          if ($pendingDeploymentStates.Count -eq 0) {
-            if ($deletedDeployments -eq 0) {
-              Write-Host "No stale Pages deployments required deletion."
-            }
-            break
-          }
-
-          if ($attempt -eq $maxAttempts) {
-            Write-Warning "Some stale Pages deployments were not deleted because they never became inactive: $($pendingDeploymentStates -join ', ')"
-            break
-          }
-
-          Write-Host "Waiting $sleepSeconds seconds for stale deployments to become inactive..."
-          Start-Sleep -Seconds $sleepSeconds
-        }

--- a/docs/presentation/LandingPage.md
+++ b/docs/presentation/LandingPage.md
@@ -43,8 +43,8 @@ python -m http.server 4173 --directory site
 
 - 公開 URL は `https://tnagata012.github.io/ClipSave/`
 - GitHub Pages の公開元は `GitHub Actions`
-- `main` に対する `site/**` または `.github/workflows/deploy-pages.yml` の変更は `Deploy Pages` workflow（`.github/workflows/deploy-pages.yml`）で自動公開する
-- `Deploy Pages` の手動実行は再公開用途に限定し、`main` ブランチからのみ実行する
+- `main` に対する `site/**` の変更は `Deploy Pages` workflow（`.github/workflows/deploy-pages.yml`）で自動公開する
+- `Deploy Pages` の手動実行は再公開や workflow 変更反映の用途に限定し、`main` ブランチからのみ実行する
 - `site/**` と `docs/presentation/LandingPage.md` だけの変更ではアプリ本体の `Dev Build` / `RC Build` は起動しない
 - `PR Check` は必須チェックを維持したまま、website-only PR のときは restore / build / test を skip する
 


### PR DESCRIPTION
## Summary
- Remove the stale Pages deployment cleanup step from `.github/workflows/deploy-pages.yml`
- Restrict automatic Pages deploys to `site/**` changes while keeping manual redeploys available
- Update the Pages documentation to match the workflow trigger behavior

## Why
- The cleanup step does not reliably remove the immediately previous Pages deployment because the older deployment can become `inactive` after the workflow has already finished
- Workflow-only edits were triggering Pages deployments even when no site content changed
- Dropping the cleanup step also removes the need for `deployments: write`

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed. Tests are not needed for this docs/CI-only change.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed. Not needed for this docs/CI-only change.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes.
