### PR TITLE
refactor: align clipboard text classification with dev docs

### DIFF
--- a/docs/dev/Architecture.md
+++ b/docs/dev/Architecture.md
@@ -74,7 +74,8 @@ flowchart TB
 - **HotkeyService**: グローバルホットキーの登録・解除・イベント
 - **SavePipeline**: 保存処理のオーケストレーション、排他制御
 - **ActiveWindowService**: アクティブウィンドウ判定、保存先フォルダ決定
-- **ClipboardService**: クリップボードからコンテンツ取得、種別判別、リトライ
+- **ClipboardService**: クリップボードからコンテンツ取得、STA 制約の管理、リトライ
+- **ClipboardTextClassifier**: テキストの種別判別（CSV / JSON / Markdown / Text）
 - **ContentEncodingService**: コンテンツ種別に応じたエンコード処理
 - **ImageEncodingService**: PNG/JPG エンコード、透過処理
 - **FileStorageService**: ファイル保存、重複対応、原子的書き込み
@@ -90,7 +91,7 @@ flowchart TB
 - `Infrastructure/Startup`: 起動時の DI 構築、ライフサイクルオーケストレーション、ウィンドウ/ホットキー協調、ホットキー受信用ウィンドウ生成
 - `ViewModels/About`, `ViewModels/Settings`: 画面機能単位の ViewModel
 - `Views/About`, `Views/Settings`: 画面機能単位の WPF ビュー
-- `Services/Encoding`: コンテンツ/画像エンコード、区切り文字テキスト変換
+- `Services/Encoding`: コンテンツ/画像エンコード、区切り文字テキスト変換、テキスト種別判別
 - `Services/Platform`: OS 連携（クリップボード、ホットキー、トレイ、単一起動、アクティブウィンドウ）
 - `Services/Persistence`: 設定・ファイル保存・クラッシュダンプなど永続化
 - `Services/Pipeline`: 保存オーケストレーション（`SavePipeline`）
@@ -194,7 +195,7 @@ ClipSave は WPF アプリケーションとして実装されており、以下
 - **実行内容**:
   - `TrayService`: NotifyIcon の操作、コンテキストメニュー表示
   - `HotkeyService`: WM_HOTKEY メッセージの受信、RegisterHotKey API 呼び出し
-  - `ClipboardService`: Clipboard API の呼び出し（STA 必須要件）
+  - `ClipboardService`: Clipboard API の呼び出し、テキストスナップショット取得（STA 必須要件）
   - `ActiveWindowService`: Shell COM を用いたエクスプローラーパス取得
   - `SavePipeline`: 画像をバックグラウンド処理可能な `BitmapSource` にデタッチ（`CopyPixels`）
   - `SettingsWindow`: XAML ビューの表示、データバインディング
@@ -202,6 +203,7 @@ ClipSave は WPF アプリケーションとして実装されており、以下
 #### バックグラウンドスレッド
 - **責務**: 非同期 I/O 処理、プロセス間通信
 - **主な実行内容**:
+  - `ClipboardTextClassifier`: 取得済みテキストの種別判別（CSV / JSON / Markdown / Text）
   - `ContentEncodingService`: 画像スナップショットのエンコード処理（画像経路）
   - `FileStorageService.SaveFileAsync()`: ファイル書き込み処理
   - `SingleInstanceService`: Named Pipe サーバー（二重起動検出用）

--- a/src/ClipSave/Services/Encoding/ClipboardTextClassifier.cs
+++ b/src/ClipSave/Services/Encoding/ClipboardTextClassifier.cs
@@ -1,0 +1,93 @@
+using ClipSave.Models;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace ClipSave.Services;
+
+internal static partial class ClipboardTextClassifier
+{
+    // Heuristic matcher used for lightweight Markdown detection.
+    [GeneratedRegex(@"^(#{1,6}\s|[-*+]\s|\d+\.\s|```|>\s|\[.+\]\(.+\)|\*\*.+\*\*|__.+__)", RegexOptions.Multiline)]
+    private static partial Regex MarkdownRegex();
+
+    public static ClipboardContent Classify(string text)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+
+        var csvContent = TryParseAsCsv(text);
+        if (csvContent != null)
+        {
+            return csvContent;
+        }
+
+        var jsonContent = TryParseAsJson(text);
+        if (jsonContent != null)
+        {
+            return jsonContent;
+        }
+
+        if (MarkdownRegex().IsMatch(text))
+        {
+            return new MarkdownContent(text);
+        }
+
+        return new TextContent(text);
+    }
+
+    private static JsonContent? TryParseAsJson(string text)
+    {
+        var trimmed = text.Trim();
+
+        if (!(trimmed.StartsWith('{') || trimmed.StartsWith('[')))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(trimmed);
+            var formatted = JsonSerializer.Serialize(doc, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            return new JsonContent(trimmed, formatted);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static CsvContent? TryParseAsCsv(string text)
+    {
+        if (!text.Contains('\t'))
+        {
+            return null;
+        }
+
+        if (!DelimitedTextCodec.TryParseTabSeparated(text, out var rows))
+        {
+            return null;
+        }
+
+        // Keep the classifier stable even when clipboard text contains trailing blank lines.
+        var effectiveRows = rows
+            .Where(r => r.Count > 1 || r.Any(cell => !string.IsNullOrEmpty(cell)))
+            .ToList();
+
+        if (effectiveRows.Count < 2)
+        {
+            return null;
+        }
+
+        if (effectiveRows.Any(r => r.Count < 2))
+        {
+            return null;
+        }
+
+        var columnCounts = effectiveRows.Select(r => r.Count).ToList();
+        var maxColumns = columnCounts.Max();
+
+        return new CsvContent(text, effectiveRows.Count, maxColumns);
+    }
+}

--- a/src/ClipSave/Services/Platform/ClipboardService.cs
+++ b/src/ClipSave/Services/Platform/ClipboardService.cs
@@ -3,13 +3,11 @@ using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Windows.Media.Imaging;
 
 namespace ClipSave.Services;
 
-public partial class ClipboardService
+public class ClipboardService
 {
     private readonly ILogger<ClipboardService> _logger;
     private const int MaxRetries = 3;
@@ -17,13 +15,9 @@ public partial class ClipboardService
     private const int TotalTimeoutMs = 300;
     private const int ClipbrdECantOpen = unchecked((int)0x800401D0);
 
-    // Heuristic matcher used for lightweight Markdown detection.
-    [GeneratedRegex(@"^(#{1,6}\s|[-*+]\s|\d+\.\s|```|>\s|\[.+\]\(.+\)|\*\*.+\*\*|__.+__)", RegexOptions.Multiline)]
-    private static partial Regex MarkdownRegex();
-
     public ClipboardService(ILogger<ClipboardService> logger)
     {
-        _logger = logger;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<ClipboardContent?> GetContentAsync()
@@ -34,7 +28,11 @@ public partial class ClipboardService
         {
             try
             {
-                var content = GetContentInternal();
+                var payload = GetClipboardPayloadInternal();
+                var content = payload == null
+                    ? null
+                    : await CreateClipboardContentAsync(payload).ConfigureAwait(true);
+
                 if (content != null)
                 {
                     var elapsed = stopwatch.ElapsedMilliseconds;
@@ -73,17 +71,14 @@ public partial class ClipboardService
         return content is ImageContent imageContent ? imageContent.Image : null;
     }
 
-    private ClipboardContent? GetContentInternal()
+    private ClipboardPayload? GetClipboardPayloadInternal()
     {
-        if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
-        {
-            throw new InvalidOperationException("ClipboardService must run on an STA thread.");
-        }
+        EnsureStaThread();
 
         var image = GetImageInternal();
         if (image != null)
         {
-            return new ImageContent(image);
+            return ClipboardPayload.FromImage(image);
         }
 
         if (System.Windows.Clipboard.ContainsText())
@@ -91,102 +86,62 @@ public partial class ClipboardService
             var text = System.Windows.Clipboard.GetText();
             if (!string.IsNullOrWhiteSpace(text))
             {
-                var csvContent = TryParseAsCsv(text);
-                if (csvContent != null)
-                {
-                    _logger.LogDebug("Detected as tabular text/CSV");
-                    return csvContent;
-                }
-
-                var jsonContent = TryParseAsJson(text);
-                if (jsonContent != null)
-                {
-                    _logger.LogDebug("Detected as JSON");
-                    return jsonContent;
-                }
-
-                if (IsMarkdown(text))
-                {
-                    _logger.LogDebug("Detected as Markdown");
-                    return new MarkdownContent(text);
-                }
-
-                _logger.LogDebug("Detected as plain text");
-                return new TextContent(text);
+                return ClipboardPayload.FromText(text);
             }
         }
 
         return null;
     }
 
-    private bool IsMarkdown(string text)
+    private async Task<ClipboardContent> CreateClipboardContentAsync(ClipboardPayload payload)
     {
-        return MarkdownRegex().IsMatch(text);
+        if (payload.Image != null)
+        {
+            return new ImageContent(payload.Image);
+        }
+
+        if (payload.Text == null)
+        {
+            throw new InvalidOperationException("Clipboard payload did not contain data.");
+        }
+
+        // Clipboard access must stay on STA, but text classification is pure CPU-bound work.
+        _logger.LogDebug("Classifying text clipboard content on a background thread");
+        var content = await Task.Run(() => ClipboardTextClassifier.Classify(payload.Text)).ConfigureAwait(true);
+        LogDetectedTextContent(content);
+        return content;
     }
 
-    private JsonContent? TryParseAsJson(string text)
+    private void LogDetectedTextContent(ClipboardContent content)
     {
-        var trimmed = text.Trim();
-
-        if (!(trimmed.StartsWith('{') || trimmed.StartsWith('[')))
+        switch (content)
         {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(trimmed);
-            var formatted = JsonSerializer.Serialize(doc, new JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
-            return new JsonContent(trimmed, formatted);
-        }
-        catch (JsonException)
-        {
-            return null;
+            case CsvContent:
+                _logger.LogDebug("Detected as tabular text/CSV");
+                break;
+            case JsonContent:
+                _logger.LogDebug("Detected as JSON");
+                break;
+            case MarkdownContent:
+                _logger.LogDebug("Detected as Markdown");
+                break;
+            case TextContent:
+                _logger.LogDebug("Detected as plain text");
+                break;
         }
     }
 
-    private CsvContent? TryParseAsCsv(string text)
-    {
-        if (!text.Contains('\t'))
-        {
-            return null;
-        }
-
-        if (!DelimitedTextCodec.TryParseTabSeparated(text, out var rows))
-        {
-            return null;
-        }
-
-        // Keep the classifier stable even when clipboard text contains trailing blank lines.
-        var effectiveRows = rows
-            .Where(r => r.Count > 1 || r.Any(cell => !string.IsNullOrEmpty(cell)))
-            .ToList();
-
-        if (effectiveRows.Count < 2)
-        {
-            return null;
-        }
-
-        if (effectiveRows.Any(r => r.Count < 2))
-        {
-            return null;
-        }
-
-        var columnCounts = effectiveRows.Select(r => r.Count).ToList();
-        var maxColumns = columnCounts.Max();
-
-        return new CsvContent(text, effectiveRows.Count, maxColumns);
-    }
-
-    private BitmapSource? GetImageInternal()
+    private static void EnsureStaThread()
     {
         if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
         {
             throw new InvalidOperationException("ClipboardService must run on an STA thread.");
         }
+    }
+
+    private BitmapSource? GetImageInternal()
+    {
+        EnsureStaThread();
 
         var pngImage = TryGetPngImage();
         if (pngImage != null)
@@ -322,5 +277,18 @@ public partial class ClipboardService
     private static bool IsClipboardLocked(Exception ex)
     {
         return ex is ExternalException && ex.HResult == ClipbrdECantOpen;
+    }
+
+    private sealed record ClipboardPayload(BitmapSource? Image, string? Text)
+    {
+        public static ClipboardPayload FromImage(BitmapSource image)
+        {
+            return new ClipboardPayload(image, null);
+        }
+
+        public static ClipboardPayload FromText(string text)
+        {
+            return new ClipboardPayload(null, text);
+        }
     }
 }

--- a/tests/ClipSave.UnitTests/Services/Encoding/ClipboardTextClassifierTests.cs
+++ b/tests/ClipSave.UnitTests/Services/Encoding/ClipboardTextClassifierTests.cs
@@ -1,0 +1,42 @@
+using ClipSave.Models;
+using ClipSave.Services;
+using FluentAssertions;
+
+namespace ClipSave.UnitTests;
+
+[UnitTest]
+public class ClipboardTextClassifierTests
+{
+    [Fact]
+    public void Classify_TabSeparatedMarkdown_PrefersCsv()
+    {
+        var content = ClipboardTextClassifier.Classify("# Header\tValue\nRow\t1");
+
+        content.Should().BeOfType<CsvContent>();
+    }
+
+    [Fact]
+    public void Classify_JsonText_ReturnsFormattedJson()
+    {
+        var content = ClipboardTextClassifier.Classify("""{"name":"test","value":123}""");
+
+        content.Should().BeOfType<JsonContent>();
+        ((JsonContent)content).FormattedJson.Should().Contain("\n");
+    }
+
+    [Fact]
+    public void Classify_Markdown_ReturnsMarkdown()
+    {
+        var content = ClipboardTextClassifier.Classify("# Title\n\nThis is **bold**.");
+
+        content.Should().BeOfType<MarkdownContent>();
+    }
+
+    [Fact]
+    public void Classify_InvalidTabularText_FallsBackToText()
+    {
+        var content = ClipboardTextClassifier.Classify("Name\tAge\nAlice");
+
+        content.Should().BeOfType<TextContent>();
+    }
+}


### PR DESCRIPTION
## Summary
- Move `ClipboardTextClassifier` into `Services/Encoding` as a pure static classifier.
- Keep `ClipboardService` focused on STA clipboard access, retry handling, and background classification dispatch.
- Update architecture docs and relocate the classifier unit tests to match the implementation structure.

## Why
- Align the clipboard classification refactor with the dev architecture and testing guidelines.
- Remove the test-only injection seam from production code while preserving the same runtime behavior.
- No product behavior or spec coverage changed; `Specification.md` and `Spec` attributes are unchanged.

## Checklist
### Change Type (choose one)
- [ ] Docs/CI/site/repo config only.
- [x] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes.
