### PR TITLE
refactor: backgroundize non-image save processing

### DIFF
--- a/docs/dev/Architecture.md
+++ b/docs/dev/Architecture.md
@@ -204,12 +204,10 @@ ClipSave は WPF アプリケーションとして実装されており、以下
 - **責務**: 非同期 I/O 処理、プロセス間通信
 - **主な実行内容**:
   - `ClipboardTextClassifier`: 取得済みテキストの種別判別（CSV / JSON / Markdown / Text）
-  - `ContentEncodingService`: 画像スナップショットのエンコード処理（画像経路）
+  - `ContentEncodingService`: 画像スナップショットとテキスト系コンテンツのエンコード処理
   - `FileStorageService.SaveFileAsync()`: ファイル書き込み処理
   - `SingleInstanceService`: Named Pipe サーバー（二重起動検出用）
   - ディスク容量チェック（保存直前）
-
-※ 非画像コンテンツのエンコードは呼び出しコンテキストで実行される場合がある
 
 #### UI スレッドとの同期
 - **同期方式**: `SynchronizationContext` による UI スレッドへの投稿（バルーン通知表示時）

--- a/src/ClipSave/Services/Pipeline/SavePipeline.cs
+++ b/src/ClipSave/Services/Pipeline/SavePipeline.cs
@@ -222,29 +222,25 @@ public class SavePipeline : IDisposable
         SaveSettings settings,
         string savePath)
     {
-        if (content is not ImageContent)
+        var processingPlan = PrepareContentProcessing(content);
+        if (!processingPlan.CanRunOnBackground)
         {
-            return await EncodeAndSaveAsync(content, settings, savePath);
-        }
-
-        var (canRunOnBackground, contentForProcessing) = PrepareForBackgroundProcessing(content);
-        if (!canRunOnBackground)
-        {
-            return await EncodeAndSaveAsync(contentForProcessing, settings, savePath);
+            return await EncodeAndSaveAsync(processingPlan.Content, settings, savePath);
         }
 
         try
         {
-            return await Task.Run(() => EncodeAndSaveAsync(contentForProcessing, settings, savePath));
+            _logger.LogDebug("Processing {ContentType} on a background thread", processingPlan.Content.Type);
+            return await Task.Run(() => EncodeAndSaveAsync(processingPlan.Content, settings, savePath));
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException ex) when (processingPlan.AllowUiThreadFallback)
         {
             _logger.LogWarning(ex, "Background image processing failed; retrying on the UI thread");
-            return await EncodeAndSaveAsync(contentForProcessing, settings, savePath);
+            return await EncodeAndSaveAsync(processingPlan.Content, settings, savePath);
         }
     }
 
-    private (bool CanRunOnBackground, ClipboardContent Content) PrepareForBackgroundProcessing(ClipboardContent content)
+    private ContentProcessingPlan PrepareContentProcessing(ClipboardContent content)
     {
         if (content is ImageContent imageContent)
         {
@@ -253,16 +249,16 @@ public class SavePipeline : IDisposable
                 var detachedImage = CreateThreadSafeImageSnapshot(imageContent.Image);
                 _logger.LogDebug("Detached image for background processing ({Width}x{Height}, {Format})",
                     detachedImage.PixelWidth, detachedImage.PixelHeight, detachedImage.Format);
-                return (true, new ImageContent(detachedImage));
+                return ContentProcessingPlan.ForBackground(new ImageContent(detachedImage), allowUiThreadFallback: true);
             }
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "Failed to detach image; processing on the UI thread");
-                return (false, content);
+                return ContentProcessingPlan.ForCurrentThread(content);
             }
         }
 
-        return (true, content);
+        return ContentProcessingPlan.ForBackground(content);
     }
 
     private bool TryGetSaveDirectory(ActiveWindowResult activeWindow, out string savePath)
@@ -420,5 +416,18 @@ public class SavePipeline : IDisposable
     private bool IsDisposeRequested()
     {
         return Volatile.Read(ref _disposeRequested) == 1;
+    }
+
+    private sealed record ContentProcessingPlan(ClipboardContent Content, bool CanRunOnBackground, bool AllowUiThreadFallback)
+    {
+        public static ContentProcessingPlan ForBackground(ClipboardContent content, bool allowUiThreadFallback = false)
+        {
+            return new ContentProcessingPlan(content, CanRunOnBackground: true, AllowUiThreadFallback: allowUiThreadFallback);
+        }
+
+        public static ContentProcessingPlan ForCurrentThread(ClipboardContent content)
+        {
+            return new ContentProcessingPlan(content, CanRunOnBackground: false, AllowUiThreadFallback: false);
+        }
     }
 }

--- a/tests/ClipSave.UnitTests/Services/Encoding/ContentEncodingServiceTests.cs
+++ b/tests/ClipSave.UnitTests/Services/Encoding/ContentEncodingServiceTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Text;
+using System.Threading;
 using System.Windows.Media.Imaging;
 
 namespace ClipSave.UnitTests;
@@ -279,5 +280,78 @@ public class ContentEncodingServiceTests
         // Assert
         extension.Should().Be("jpg");
         data.Take(3).Should().Equal(new byte[] { 0xFF, 0xD8, 0xFF }); // JPEG header
+    }
+
+    [Fact]
+    public void Encode_TextContent_OnMtaThread_Succeeds()
+    {
+        var (data, extension) = RunOnMtaThread(() => _service.Encode(
+            new TextContent("Hello from MTA"),
+            _defaultSettings));
+
+        extension.Should().Be("txt");
+        Encoding.UTF8.GetString(data).Should().Be("Hello from MTA");
+    }
+
+    [Fact]
+    public void Encode_MarkdownContent_OnMtaThread_Succeeds()
+    {
+        var markdown = "# Title\n\n- Item";
+        var (data, extension) = RunOnMtaThread(() => _service.Encode(
+            new MarkdownContent(markdown),
+            _defaultSettings));
+
+        extension.Should().Be("md");
+        Encoding.UTF8.GetString(data).Should().Be(markdown);
+    }
+
+    [Fact]
+    public void Encode_JsonContent_OnMtaThread_Succeeds()
+    {
+        var formattedJson = """
+            {
+              "name": "test"
+            }
+            """;
+        var (data, extension) = RunOnMtaThread(() => _service.Encode(
+            new JsonContent("""{"name":"test"}""", formattedJson),
+            _defaultSettings));
+
+        extension.Should().Be("json");
+        Encoding.UTF8.GetString(data).Should().Be(formattedJson);
+    }
+
+    [Fact]
+    public void Encode_CsvContent_OnMtaThread_Succeeds()
+    {
+        var (data, extension) = RunOnMtaThread(() => _service.Encode(
+            new CsvContent("Name\tAge\nAlice\t30", 2, 2),
+            _defaultSettings));
+
+        extension.Should().Be("csv");
+        Encoding.UTF8.GetString(data.Skip(3).ToArray()).Should().Contain("Name,Age");
+    }
+
+    private static T RunOnMtaThread<T>(Func<T> action)
+    {
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                tcs.SetResult(action());
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+
+        thread.IsBackground = true;
+        thread.SetApartmentState(ApartmentState.MTA);
+        thread.Start();
+
+        return tcs.Task.GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
## Summary
- Run text, Markdown, JSON, and CSV save processing on a background thread in `SavePipeline`.
- Keep image-specific snapshot preparation and UI-thread fallback behavior behind a `ContentProcessingPlan`.
- Add MTA coverage for non-image encoding and update the architecture doc to match the new threading model.

## Why
- Reduce UI-thread blocking during non-image saves.
- Document and verify that non-image encoding is safe to run from background threads.

## Checklist
### Change Type (choose one)
- [ ] Docs/CI/site/repo config only.
- [x] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [ ] No spec impact.
- [x] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes.

## Notes
- `Specification.md` and `Spec` attributes were not changed, so `./scripts/check-spec-coverage.ps1` was not needed.
