### PR TITLE
chore: simplify release branch input

### DIFF
--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (X.Y.0)'
+        description: 'Release series (X.Y)'
         required: true
         type: string
       next_main_version:
@@ -47,6 +47,24 @@ jobs:
         git config user.name "${{ env.GIT_AUTHOR_NAME }}"
         git config user.email "${{ env.GIT_AUTHOR_EMAIL }}"
 
+    - name: Resolve release series
+      id: version
+      shell: pwsh
+      run: |
+        $inputVersion = "${{ inputs.version }}".Trim()
+        if ($inputVersion -match '^(?<major>\d+)\.(?<minor>\d+)$') {
+          $major = [int]$matches['major']
+          $minor = [int]$matches['minor']
+          $releaseVersion = "$major.$minor.0"
+        } else {
+          throw "Invalid version format: $inputVersion (expected X.Y)"
+        }
+
+        echo "RELEASE_VERSION=$releaseVersion" >> $env:GITHUB_OUTPUT
+        echo "RELEASE_SERIES=$major.$minor" >> $env:GITHUB_OUTPUT
+        Write-Host "Resolved release series: $major.$minor"
+        Write-Host "Resolved release version: $releaseVersion"
+
     - name: Create release and main bump branches
       shell: pwsh
       run: |
@@ -56,7 +74,7 @@ jobs:
         }
 
         & ./scripts/create-release-branch.ps1 `
-          -Version "${{ inputs.version }}" `
+          -Version "${{ steps.version.outputs.RELEASE_SERIES }}" `
           -MainBranch "main" `
           @extraArgs `
           -Push
@@ -67,9 +85,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        $version = "${{ inputs.version }}"
+        $version = "${{ steps.version.outputs.RELEASE_VERSION }}"
         if ($version -notmatch '^(?<major>\d+)\.(?<minor>\d+)\.0$') {
-          throw "Invalid version format: $version (expected X.Y.0)"
+          throw "Invalid resolved version format: $version (expected X.Y.0)"
         }
 
         $major = [int]$matches['major']
@@ -130,9 +148,9 @@ jobs:
     - name: Summary
       shell: pwsh
       run: |
-        $version = "${{ inputs.version }}"
+        $version = "${{ steps.version.outputs.RELEASE_VERSION }}"
         if ($version -notmatch '^(?<major>\d+)\.(?<minor>\d+)\.0$') {
-          throw "Invalid version format: $version (expected X.Y.0)"
+          throw "Invalid resolved version format: $version (expected X.Y.0)"
         }
         $major = [int]$matches['major']
         $minor = [int]$matches['minor']

--- a/docs/release/ReleaseGuide.md
+++ b/docs/release/ReleaseGuide.md
@@ -19,7 +19,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | [pr-check.yml](../../.github/workflows/pr-check.yml) | PR（`main`, `release/*`） | 品質ゲート | `TestResults/**/*.trx` |
 | [deploy-pages.yml](../../.github/workflows/deploy-pages.yml) | `main` push（`site/**`） / 手動（`main` のみ） | GitHub Pages 公開 | GitHub Pages site artifact |
-| [prepare-release-branch.yml](../../.github/workflows/prepare-release-branch.yml) | 手動（`X.Y.0`） | `release/X.Y` 作成 + `main` 側 bump ブランチ作成、任意で PR 作成 | `release/X.Y`, `chore/bump-main-to-*` |
+| [prepare-release-branch.yml](../../.github/workflows/prepare-release-branch.yml) | 手動（`X.Y`。内部で `X.Y.0` に展開） | `release/X.Y` 作成 + `main` 側 bump ブランチ作成、任意で PR 作成 | `release/X.Y`, `chore/bump-main-to-*` |
 | [prepare-patch-release.yml](../../.github/workflows/prepare-patch-release.yml) | 手動（`release/X.Y`） | patch init ブランチ作成、任意で PR 作成 | `chore/release-X.Y.(Z+1)-init` |
 | [dev-build.yml](../../.github/workflows/dev-build.yml) | `main` push（`docs/**`, `*.md`, `site/**`, `.github/workflows/deploy-pages.yml` のみ変更時は除く） / 手動 | 開発成果物生成（未署名） | `dev-package-*`, `dev-latest`, `SHA256SUMS.txt`, GitHub 上に記録される Artifact Attestation |
 | [rc-build.yml](../../.github/workflows/rc-build.yml) | `release/*` push（`docs/**`, `*.md`, `site/**`, `.github/workflows/deploy-pages.yml` のみ変更時は除く） / 手動 | 公開候補生成（未署名） | `rc-package-*`, `rc-X.Y-latest`, `SHA256SUMS.txt`, GitHub 上に記録される Artifact Attestation |
@@ -70,7 +70,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 
 ### メジャー/マイナーリリース
 
-1. `Prepare Release Branch`（推奨）または `create-release-branch.ps1` で `release/X.Y` を作成する。
+1. `Prepare Release Branch`（推奨、workflow 入力は `X.Y`。内部で `X.Y.0` に展開）または `create-release-branch.ps1`（`-Version X.Y`）で `release/X.Y` を作成する。
 2. 必要に応じて `next_main_version` / `-NextMainVersion` を指定し、`main` を次の近接系列ではなく将来系列（例: `0.5.0`）へ進める。
 3. `chore/bump-main-to-* -> main` の PR をレビューしてマージする。`Prepare Release Branch` workflow は既定でこの PR を自動作成する。
 4. `release/X.Y` の安定化を PR で反映する。

--- a/scripts/create-release-branch.ps1
+++ b/scripts/create-release-branch.ps1
@@ -10,7 +10,7 @@
     - Package.appxmanifest always keeps numeric X.Y.Z.0
 
 .PARAMETER Version
-    Target release version (e.g., 1.3.0)
+    Target release series (e.g., 1.3)
 
 .PARAMETER MainBranch
     Trunk branch name (default: main)
@@ -26,15 +26,15 @@
     Push branches to origin (default: false)
 
 .EXAMPLE
-    .\create-release-branch.ps1 -Version 1.3.0
+    .\create-release-branch.ps1 -Version 1.3
     # Creates release/1.3 at 1.3.0 and creates a PR branch for main=1.4.0
 
 .EXAMPLE
-    .\create-release-branch.ps1 -Version 0.1.0 -NextMainVersion 0.5.0
+    .\create-release-branch.ps1 -Version 0.1 -NextMainVersion 0.5.0
     # Creates release/0.1 at 0.1.0 and creates a PR branch for main=0.5.0
 
 .EXAMPLE
-    .\create-release-branch.ps1 -Version 1.3.0 -Push
+    .\create-release-branch.ps1 -Version 1.3 -Push
     # Same as above, then pushes release + PR branch
 #>
 
@@ -58,21 +58,17 @@ function Fail([string]$Message) {
     exit 1
 }
 
-# Validate target release version format (X.Y.Z)
-if ($Version -notmatch '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
-    Fail "Invalid version format. Use X.Y.Z (example: 1.3.0)."
+# Validate target release series format (X.Y)
+if ($Version -notmatch '^(?<major>\d+)\.(?<minor>\d+)$') {
+    Fail "Invalid version format. Use X.Y (example: 1.3)."
 }
 
 $major = [int]$matches['major']
 $minor = [int]$matches['minor']
-$patch = [int]$matches['patch']
-
-if ($patch -ne 0) {
-    Fail "Release branch creation only supports .0 versions (example: 1.3.0). Use release branch updates for patch releases."
-}
+$releaseVersion = "$major.$minor.0"
 
 $branchName = "release/$major.$minor"
-$releaseVersionTuple = @($major, $minor, $patch)
+$releaseVersionTuple = @($major, $minor, 0)
 
 if ($NextMainVersion) {
     if ($NextMainVersion -notmatch '^(?<nextMajor>\d+)\.(?<nextMinor>\d+)\.(?<nextPatch>\d+)$') {
@@ -94,7 +90,7 @@ if ($NextMainVersion) {
         ($nextVersionTuple[0] -eq $releaseVersionTuple[0] -and $nextVersionTuple[1] -eq $releaseVersionTuple[1] -and $nextVersionTuple[2] -gt $releaseVersionTuple[2])
 
     if (-not $isGreater) {
-        Fail "NextMainVersion must be greater than release version $Version. Actual: $NextMainVersion"
+        Fail "NextMainVersion must be greater than release version $releaseVersion. Actual: $NextMainVersion"
     }
 
     $nextMainVersion = "$nextMajor.$nextMinor.$nextPatch"
@@ -109,7 +105,7 @@ $propsPath = Join-Path $projectRoot "Directory.Build.props"
 $manifestPath = Join-Path $projectRoot "src/ClipSave.Package/Package.appxmanifest"
 
 Write-Host "=== Create Release Branch (Trunk-Based Development) ===" -ForegroundColor Cyan
-Write-Host "Release branch: $branchName (version $Version)" -ForegroundColor White
+Write-Host "Release branch: $branchName (version $releaseVersion)" -ForegroundColor White
 Write-Host "Main branch   : $MainBranch (target version $nextMainVersion via PR branch)" -ForegroundColor White
 Write-Host "PR branch     : $mainBumpBranch" -ForegroundColor White
 Write-Host ""
@@ -172,7 +168,7 @@ try {
     $mainMajor = [int]$matches['major']
     $mainMinor = [int]$matches['minor']
     if ($mainMajor -ne $major -or $mainMinor -ne $minor) {
-        Fail "Target release version $Version does not match current $MainBranch line $mainVersion. Use a matching X.Y.0 version."
+        Fail "Target release series $Version does not match current $MainBranch line $mainVersion. Use a matching X.Y series."
     }
 
     # 4. Check if target branches already exist (local or remote)
@@ -205,21 +201,21 @@ try {
     }
 
     # 6. Update and commit release branch versions
-    Write-Host "[6/9] Updating release branch version to $Version..." -ForegroundColor Yellow
+    Write-Host "[6/9] Updating release branch version to $releaseVersion..." -ForegroundColor Yellow
     [xml]$props = Get-Content $propsPath
-    $props.Project.PropertyGroup.Version = $Version
+    $props.Project.PropertyGroup.Version = $releaseVersion
     $props.Save($propsPath)
-    Write-Host "  [OK] Directory.Build.props = $Version" -ForegroundColor Green
+    Write-Host "  [OK] Directory.Build.props = $releaseVersion" -ForegroundColor Green
 
     [xml]$manifest = Get-Content $manifestPath
-    $manifest.Package.Identity.Version = "$Version.0"
+    $manifest.Package.Identity.Version = "$releaseVersion.0"
     $manifest.Save($manifestPath)
-    Write-Host "  [OK] Package.appxmanifest = $Version.0" -ForegroundColor Green
+    Write-Host "  [OK] Package.appxmanifest = $releaseVersion.0" -ForegroundColor Green
 
     git add Directory.Build.props src/ClipSave.Package/Package.appxmanifest
     git diff --staged --quiet
     if ($LASTEXITCODE -ne 0) {
-        git commit -m "chore: set release version to $Version"
+        git commit -m "chore: set release version to $releaseVersion"
         if ($LASTEXITCODE -ne 0) {
             Fail "Failed to commit version update on release branch."
         }
@@ -292,12 +288,12 @@ try {
     Write-Host "[OK] Release branch workflow completed." -ForegroundColor Green
     Write-Host ""
     Write-Host "Summary:" -ForegroundColor Cyan
-    Write-Host "  Release: $branchName -> $Version" -ForegroundColor White
+    Write-Host "  Release: $branchName -> $releaseVersion" -ForegroundColor White
     Write-Host "  Main PR: $mainBumpBranch -> $nextMainVersion (target: $MainBranch)" -ForegroundColor White
     Write-Host ""
     Write-Host "Next steps:" -ForegroundColor Yellow
     Write-Host "1. Keep user-facing changes in CHANGELOG.md under [Unreleased] while release contents are still moving."
-    Write-Host "2. Before tagging, move shipped items in the last release-side PR (typically a stabilization/RC PR) to [$Version] - YYYY-MM-DD (see docs/release/ReleaseNotes.md)."
+    Write-Host "2. Before tagging, move shipped items in the last release-side PR (typically a stabilization/RC PR) to [$releaseVersion] - YYYY-MM-DD (see docs/release/ReleaseNotes.md)."
     if (-not $Push) {
         Write-Host "3. Push both branches:"
         Write-Host "   git push -u origin $branchName"


### PR DESCRIPTION
## Summary
- Change Prepare Release Branch to accept X.Y and expand it to X.Y.0 internally.
- Update create-release-branch.ps1 to use the same X.Y input contract.
- Refresh the release guide and note the local validation used for this change.

## Why
- The patch segment is fixed at branch creation time, so requiring X.Y.0 adds noise without adding signal.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] ./scripts/run-tests.ps1 -Configuration Release succeeded locally, or documented why it is not needed.
- [ ] If Specification.md or Spec attributes changed: ./scripts/check-spec-coverage.ps1 succeeded locally.

Tests are not needed because this change only affects release automation and documentation. Local checks run: actionlint .github/workflows/prepare-release-branch.yml, PowerShell parse for scripts/create-release-branch.ps1, and ./scripts/assert-version-policy.ps1 -BranchName main.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Changelog (choose one)
- [x] No user-facing change (Changelog N/A).
- [ ] Updated CHANGELOG.md ([Unreleased]) for user-facing changes.