### PR TITLE
fix: avoid false branch-state failures in release workflows

### DIFF
--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -171,6 +171,22 @@ jobs:
       shell: pwsh
       working-directory: repo
       run: |
+        function Get-RemoteBranchExists([string]$BranchName) {
+          git ls-remote --exit-code --heads origin $BranchName *> $null
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -eq 0) {
+            $global:LASTEXITCODE = 0
+            return $true
+          }
+
+          if ($exitCode -eq 2) {
+            $global:LASTEXITCODE = 0
+            return $false
+          }
+
+          throw "Failed to inspect origin/$BranchName (git ls-remote exit code $exitCode)."
+        }
+
         function Get-VersionFromGitObject([string]$ObjectRef) {
           $content = git show $ObjectRef 2>$null
           if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($content -join "`n"))) {
@@ -190,8 +206,7 @@ jobs:
         $expectedVersion = "${{ steps.patch_target.outputs.PATCH_VERSION }}"
         $assertScript = Join-Path $env:GITHUB_WORKSPACE "tooling/scripts/assert-version-policy.ps1"
 
-        git ls-remote --exit-code --heads origin $patchBranch *> $null
-        $patchExists = ($LASTEXITCODE -eq 0)
+        $patchExists = Get-RemoteBranchExists $patchBranch
         if ($patchExists) {
           git fetch --no-tags origin "$patchBranch"
           if ($LASTEXITCODE -ne 0) {

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -144,7 +144,18 @@ jobs:
       run: |
         function Get-RemoteBranchExists([string]$BranchName) {
           git ls-remote --exit-code --heads origin $BranchName *> $null
-          return ($LASTEXITCODE -eq 0)
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -eq 0) {
+            $global:LASTEXITCODE = 0
+            return $true
+          }
+
+          if ($exitCode -eq 2) {
+            $global:LASTEXITCODE = 0
+            return $false
+          }
+
+          throw "Failed to inspect origin/$BranchName (git ls-remote exit code $exitCode)."
         }
 
         function Get-VersionFromGitObject([string]$ObjectRef) {


### PR DESCRIPTION
## Summary
- Treat git ls-remote --exit-code branch probes as expected alse results when the remote branch does not exist yet.
- Fix prepare-release.yml so initial release preparation can continue when neither target branch exists.
- Apply the same remote-branch probe handling to prepare-patch-release.yml to avoid the same failure mode there.

## Why
- git ls-remote --exit-code returns a non-zero exit code when a branch is absent, which is expected during first-time release preparation.
- The workflows were leaving that exit code in $LASTEXITCODE, so the PowerShell step could still fail after successfully deciding create_all or create_new.
- This change normalizes the expected "not found" case to a successful workflow step while still failing on real git errors.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] ./scripts/run-tests.ps1 -Configuration Release succeeded locally, or documented why it is not needed.
- [ ] If Specification.md or Spec attributes changed: ./scripts/check-spec-coverage.ps1 succeeded locally.

Verification note: workflow-only change. Product tests were not needed. ctionlint .github/workflows/prepare-release.yml .github/workflows/prepare-patch-release.yml succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Release Notes (choose one)
- [ ] User-facing change. Updated the relevant release-notes issue (Release Notes: Unreleased for main-bound work, Release Notes: X.Y for release-line work).
- [x] No user-facing change. No release-notes update needed.