### PR TITLE
fix: avoid release-line issue lookup race

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -305,7 +305,9 @@ jobs:
             throw "Failed to create release-line issue '$lineTitle'."
           }
 
-          $lineIssue = Get-GitHubIssueByExactTitle -Repository $repo -Title $lineTitle
+          $lineIssue = [PSCustomObject]@{
+            Url = $createdUrl.Trim()
+          }
           $lineAction = "created"
           Write-Host "Created release-line issue: $($lineIssue.Url)"
         } elseif (([string]$lineIssue.State).Trim().ToLowerInvariant() -ne "open") {


### PR DESCRIPTION
## Summary
- Keep the Prepare Release workflow from re-querying a release-line issue immediately after creating it.
- Reuse the URL returned by gh issue create for the created case instead of doing an exact-title lookup again.

## Why
- The workflow could create Release Notes: X.Y successfully and then fail in the same step when the follow-up exact-title query lagged behind GitHub issue indexing.
- That makes first-time release-line preparation fail even though the issue already exists.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] ./scripts/run-tests.ps1 -Configuration Release succeeded locally, or documented why it is not needed.
- [ ] If Specification.md or Spec attributes changed: ./scripts/check-spec-coverage.ps1 succeeded locally.

Verification note: workflow-only change. Product tests were not needed. actionlint on .github/workflows/prepare-release.yml succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Release Notes (choose one)
- [ ] User-facing change. Updated the relevant release-notes issue (Release Notes: Unreleased for main-bound work, Release Notes: X.Y for release-line work).
- [x] No user-facing change. No release-notes update needed.