### PR TITLE
fix: harden prepare release argument binding

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -331,16 +331,18 @@ jobs:
       if: ${{ steps.branch_state.outputs.BRANCH_MODE == 'create_all' }}
       shell: pwsh
       run: |
-        $extraArgs = @()
-        if ("${{ steps.targets.outputs.NEXT_MAIN_VERSION }}".Trim() -ne "") {
-          $extraArgs += @("-NextMainVersion", "${{ steps.targets.outputs.NEXT_MAIN_VERSION }}")
+        $scriptArgs = @{
+          Version = "${{ steps.version.outputs.RELEASE_SERIES }}".Trim()
+          MainBranch = "main"
+          Push = $true
         }
 
-        & ./scripts/create-release-branch.ps1 `
-          -Version "${{ steps.version.outputs.RELEASE_SERIES }}" `
-          -MainBranch "main" `
-          @extraArgs `
-          -Push
+        $nextMainVersion = "${{ steps.targets.outputs.NEXT_MAIN_VERSION }}".Trim()
+        if ($nextMainVersion -ne "") {
+          $scriptArgs.NextMainVersion = $nextMainVersion
+        }
+
+        & ./scripts/create-release-branch.ps1 @scriptArgs
 
     - name: Create PR for main version bump branch
       if: ${{ inputs.create_main_bump_pr }}

--- a/scripts/create-release-branch.ps1
+++ b/scripts/create-release-branch.ps1
@@ -62,6 +62,18 @@ $manifestPath = Join-Path $projectRoot "src/ClipSave.Package/Package.appxmanifes
 
 . "$projectRoot\scripts\release-series-policy.ps1"
 
+if ($null -ne $Version) {
+    $Version = $Version.Trim()
+}
+
+if ($null -ne $MainBranch) {
+    $MainBranch = $MainBranch.Trim()
+}
+
+if ($null -ne $NextMainVersion) {
+    $NextMainVersion = $NextMainVersion.Trim()
+}
+
 Write-Host "=== Create Release Branch (Trunk-Based Development) ===" -ForegroundColor Cyan
 
 Push-Location $projectRoot


### PR DESCRIPTION
## Summary
- Trim create-release-branch.ps1 string inputs before validation so workflow-provided values do not fail on hidden whitespace.
- Change Prepare Release to call create-release-branch.ps1 via named hashtable splatting instead of array-style argument expansion.

## Why
- The workflow resolved next_main_version as 0.2.0 correctly, but branch creation could still fail when the handoff into create-release-branch.ps1 introduced unstable argument parsing or hidden whitespace.
- The array-based call path was harder to reason about and more sensitive to PowerShell argument handling than a named parameter splat.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] ./scripts/run-tests.ps1 -Configuration Release succeeded locally, or documented why it is not needed.
- [ ] If Specification.md or Spec attributes changed: ./scripts/check-spec-coverage.ps1 succeeded locally.

Verification note: workflow/script-only change. Product tests were not needed. actionlint on .github/workflows/prepare-release.yml and PowerShell parse for scripts/create-release-branch.ps1 succeeded locally. In clean local clones, create-release-branch.ps1 also succeeded with NextMainVersion values containing trailing CRLF and with workflow-equivalent named splat invocation.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Release Notes (choose one)
- [ ] User-facing change. Updated the relevant release-notes issue (Release Notes: Unreleased for main-bound work, Release Notes: X.Y for release-line work).
- [x] No user-facing change. No release-notes update needed.