### PR TITLE
fix: allow release branch creation before checks

### DIFF
--- a/.github/rulesets/protect-release-branches.json
+++ b/.github/rulesets/protect-release-branches.json
@@ -28,6 +28,7 @@
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
         "required_status_checks": [
           {
             "context": "check"


### PR DESCRIPTION
## Summary
- Allow release/* branches to be created before required status checks are enforced.
- Keep the required check itself in place for subsequent pushes and pull request merges on release branches.

## Why
- Prepare Release now completes local branch creation, but the first push to a new release/X.Y branch is rejected by the active release ruleset because it requires the check status before the branch exists.
- That makes first-time release branch creation impossible even though later updates should still stay protected by the same required check.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] ./scripts/run-tests.ps1 -Configuration Release succeeded locally, or documented why it is not needed.
- [ ] If Specification.md or Spec attributes changed: ./scripts/check-spec-coverage.ps1 succeeded locally.

Verification note: ruleset-definition-only change. Product tests were not needed. The JSON definition was parsed locally, and the failing Prepare Release run 23328637033 showed the active release ruleset rejecting refs/heads/release/0.1 because required status check check was enforced on branch creation.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Release Notes (choose one)
- [ ] User-facing change. Updated the relevant release-notes issue (Release Notes: Unreleased for main-bound work, Release Notes: X.Y for release-line work).
- [x] No user-facing change. No release-notes update needed.