### PR TITLE
fix: recreate missing prepare release bump branch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -235,12 +235,16 @@ jobs:
         }
 
         if (-not $releaseExists) {
+          if ($mainBumpExists) {
+            throw "Unexpected prepare-release state. Main bump branch '$mainBumpBranch' exists, but release branch '$releaseBranch' does not."
+          }
+
           $branchMode = "create_all"
+        } elseif (-not $mainBumpExists) {
+          $branchMode = "create_main_bump_only"
+          Write-Warning "Release branch already exists and will be reused. Missing main bump branch '$mainBumpBranch' will be recreated from the current main branch."
         } else {
           $branchMode = "reuse_existing"
-          if (-not $mainBumpExists) {
-            Write-Warning "Release branch already exists and will be reused. Missing main bump branch '$mainBumpBranch' will not be recreated automatically on rerun."
-          }
         }
 
         echo "BRANCH_MODE=$branchMode" >> $env:GITHUB_OUTPUT
@@ -343,8 +347,59 @@ jobs:
 
         & ./scripts/create-release-branch.ps1 @scriptArgs
 
+    - name: Create missing main bump branch
+      if: ${{ steps.branch_state.outputs.BRANCH_MODE == 'create_main_bump_only' }}
+      shell: pwsh
+      run: |
+        $mainBranch = "main"
+        $mainBumpBranch = "${{ steps.targets.outputs.MAIN_BUMP_BRANCH }}".Trim()
+        $nextMainVersion = "${{ steps.targets.outputs.NEXT_MAIN_VERSION }}".Trim()
+        $propsPath = "Directory.Build.props"
+        $manifestPath = "src/ClipSave.Package/Package.appxmanifest"
+
+        git checkout $mainBranch
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to checkout $mainBranch."
+        }
+
+        git checkout -b $mainBumpBranch
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to create missing main bump branch '$mainBumpBranch'."
+        }
+
+        [xml]$props = Get-Content $propsPath
+        $props.Project.PropertyGroup.Version = $nextMainVersion
+        $props.Save($propsPath)
+        Write-Host "Updated Directory.Build.props to $nextMainVersion"
+
+        [xml]$manifest = Get-Content $manifestPath
+        $manifest.Package.Identity.Version = "$nextMainVersion.0"
+        $manifest.Save($manifestPath)
+        Write-Host "Updated Package.appxmanifest to $nextMainVersion.0"
+
+        git add Directory.Build.props src/ClipSave.Package/Package.appxmanifest
+        git diff --staged --quiet
+        if ($LASTEXITCODE -ne 0) {
+          git commit -m "chore: bump main version to $nextMainVersion"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to commit version update on '$mainBumpBranch'."
+          }
+        } else {
+          Write-Host "No version changes detected for '$mainBumpBranch'."
+        }
+
+        ./scripts/assert-version-policy.ps1 -BranchName $mainBranch
+        if ($LASTEXITCODE -ne 0) {
+          throw "Version validation failed on '$mainBumpBranch'."
+        }
+
+        git push -u origin $mainBumpBranch
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to push '$mainBumpBranch'."
+        }
+
     - name: Create PR for main version bump branch
-      if: ${{ inputs.create_main_bump_pr && (steps.branch_state.outputs.BRANCH_MODE == 'create_all' || steps.branch_state.outputs.MAIN_BUMP_EXISTS == 'true') }}
+      if: ${{ inputs.create_main_bump_pr && (steps.branch_state.outputs.BRANCH_MODE == 'create_all' || steps.branch_state.outputs.BRANCH_MODE == 'create_main_bump_only' || steps.branch_state.outputs.MAIN_BUMP_EXISTS == 'true') }}
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
@@ -408,7 +463,7 @@ jobs:
         }
 
     - name: Explain skipped main bump PR creation
-      if: ${{ inputs.create_main_bump_pr && steps.branch_state.outputs.BRANCH_MODE != 'create_all' && steps.branch_state.outputs.MAIN_BUMP_EXISTS != 'true' }}
+      if: ${{ inputs.create_main_bump_pr && steps.branch_state.outputs.BRANCH_MODE != 'create_all' && steps.branch_state.outputs.BRANCH_MODE != 'create_main_bump_only' && steps.branch_state.outputs.MAIN_BUMP_EXISTS != 'true' }}
       shell: pwsh
       run: |
         $mainBumpBranch = "${{ steps.targets.outputs.MAIN_BUMP_BRANCH }}"
@@ -439,7 +494,7 @@ jobs:
 
         if (-not $prRequested) {
           $prStatus = "disabled"
-        } elseif ($branchMode -eq "create_all" -or $mainBumpExists) {
+        } elseif ($branchMode -eq "create_all" -or $branchMode -eq "create_main_bump_only" -or $mainBumpExists) {
           $prStatus = "attempted"
         } else {
           $prStatus = "skipped (missing main bump branch)"

--- a/docs/release/ReleaseGuide.md
+++ b/docs/release/ReleaseGuide.md
@@ -34,7 +34,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 - `pr-check.yml` は workflow lint を常時実行し、website-only PR（`site/**`, `.github/workflows/deploy-pages.yml`, `docs/presentation/LandingPage.md` のみ変更）のときはアプリ本体の restore / security / build / test / spec coverage を skip する。
 - `deploy-pages.yml` は `workflow_dispatch` でも `main` 以外では失敗するため、手動実行は `main` を前提とする。
 - `rc-X.Y-latest` の GitHub Release は候補版として常に `prerelease` 表示にする。
-- `Prepare Release` は `release/X.Y` が既に存在していても、その branch を再利用して継続できる。削除済みの `main` 側 bump ブランチは rerun で自動再作成しない。
+- `Prepare Release` は `release/X.Y` が既に存在していても、その branch を再利用して継続できる。`main` 側 bump ブランチだけが欠けている rerun では、その branch を再作成して PR 作成まで進める。
 
 ## 実行前チェック
 


### PR DESCRIPTION
## Summary
- Recreate the missing main bump branch on `Prepare Release` reruns when `release/X.Y` already exists.
- Keep the run summary and warnings aligned with the actual PR-creation behavior.
- Update the release guide to describe the rerun recovery path.

## Why
- The current workflow reuses an existing `release/X.Y`, but it skips the combined branch-creation step entirely, so a missing `chore/bump-main-to-*` branch is never recreated.
- That leaves reruns in a misleading "success" state where the requested main bump PR still cannot be opened.
- The practical fix is to treat release-branch reuse and main-bump-branch creation independently.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [ ] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [ ] No spec impact.
- [x] Updated specs/docs for behavioral changes.

### Release Notes (choose one)
- [ ] User-facing change. Updated the relevant release-notes issue (`Release Notes: Unreleased` for main-bound work, `Release Notes: X.Y` for release-line work).
- [x] No user-facing change. No release-notes update needed.

Validation notes:
- `./scripts/assert-version-policy.ps1 -BranchName main`
- Workflow branch-mode logic was checked against the current remote state to confirm it selects `create_main_bump_only` when `release/0.1` exists and `chore/bump-main-to-0.2.0` does not.
- `./scripts/run-tests.ps1 -Configuration Release` was not run because this PR only changes workflow/doc behavior and the targeted validation above covers the modified paths.
