### PR TITLE
chore: finalize patch version in release workflow

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -310,7 +310,8 @@ jobs:
 
           > Unsigned package by channel policy. Verify `SHA256SUMS.txt` and GitHub Artifact Attestation (`gh attestation verify`) before use.
           > This floating release tag always points to the latest candidate for `${{ github.ref_name }}` and can be replaced by a newer build.
-          > RC package version uses `X.Y.Z.B` and the build segment tracks the branch-scoped `rc-build` counter.
+          > RC package version uses the release-branch base version `X.Y.0.B`, and the build segment tracks the branch-scoped `rc-build` counter.
+          > `Release Finalize` keeps the source build number `B` but rewrites the patch segment to the operator-selected finalized version `X.Y.Z.B`.
           > The `B` counter resets when a new `release/X.Y` branch starts.
         files: |
           output/**/*.msixbundle

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       patch:
-        description: 'Target patch number (Z, use 0 for the first X.Y.0 release)'
+        description: 'Target finalized patch number (Z, use 0 for the first X.Y.0 release)'
         required: true
         type: string
       create_version_tag:
@@ -129,16 +129,19 @@ jobs:
           Write-Error "Configured version '$configuredVersion' does not match selected release branch '$releaseBranch'."
           exit 1
         }
-        if ($configuredVersion -ne $version) {
-          Write-Error "Selected patch '$patch' resolved to version '$version', but Directory.Build.props is '$configuredVersion'."
+        $branchVersion = "$($matches['major']).$($matches['minor']).0"
+        if ($configuredVersion -ne $branchVersion) {
+          Write-Error "Selected release branch '$releaseBranch' must keep repository version '$branchVersion'. Actual: '$configuredVersion'."
           exit 1
         }
 
         echo "VERSION=$version" >> $env:GITHUB_OUTPUT
         echo "PATCH=$patch" >> $env:GITHUB_OUTPUT
+        echo "BRANCH_VERSION=$branchVersion" >> $env:GITHUB_OUTPUT
         echo "BUILD_STORE_PACKAGE=${{ steps.source.outputs.BUILD_STORE_PACKAGE }}" >> $env:GITHUB_OUTPUT
         echo "RELEASE_BRANCH=$releaseBranch" >> $env:GITHUB_OUTPUT
-        echo "Resolved version: $version"
+        echo "Resolved branch version: $branchVersion"
+        echo "Resolved finalized version: $version"
 
     - name: Read existing GitHub Release metadata
       id: existing_release
@@ -205,6 +208,7 @@ jobs:
         $repo = "${{ github.repository }}"
         $releaseBranch = "${{ steps.source.outputs.RELEASE_BRANCH }}"
         $version = "${{ steps.target.outputs.VERSION }}"
+        $branchVersion = "${{ steps.target.outputs.BRANCH_VERSION }}"
         $hasStoreSubmission = "${{ steps.existing_release.outputs.HAS_STORE_SUBMISSION }}" -eq "true"
         $branchHeadCommit = (git rev-parse HEAD).Trim()
         if (-not $branchHeadCommit -or $branchHeadCommit -notmatch '^[0-9a-f]{40}$') {
@@ -214,7 +218,7 @@ jobs:
 
         if ($hasStoreSubmission) {
           $selectedCommit = "${{ steps.existing_release.outputs.ARCHIVE_COMMIT }}".Trim()
-          $packageVersion = "${{ steps.existing_release.outputs.ARCHIVE_PACKAGE_VERSION }}".Trim()
+          $sourcePackageVersion = "${{ steps.existing_release.outputs.ARCHIVE_PACKAGE_VERSION }}".Trim()
           $sourceMode = "locked_store_submission"
           $sourceLabel = "Store-submitted archive"
 
@@ -222,10 +226,11 @@ jobs:
             Write-Error "GitHub Release '$version' has a Store Submission Log entry, but the archive commit is missing or invalid. Fix the release metadata before rerunning Release Finalize."
             exit 1
           }
-          if (-not $packageVersion) {
+          if (-not $sourcePackageVersion) {
             Write-Error "GitHub Release '$version' has a Store Submission Log entry, but the archive package version is missing. Fix the release metadata before rerunning Release Finalize."
             exit 1
           }
+          $expectedSourceVersion = $version
         } else {
           $rcState = Get-RcChannelState -Repository $repo -ReleaseBranch $releaseBranch
           if ($rcState.IsDraft) {
@@ -236,8 +241,8 @@ jobs:
             Write-Error "RC channel '$($rcState.TagName)' does not expose a parsable version. Fix the RC channel metadata before running Release Finalize."
             exit 1
           }
-          if ($rcState.Version -ne $version) {
-            Write-Error "Latest RC candidate for '$releaseBranch' is version '$($rcState.Version)', but Release Finalize target is '$version'. Run a successful RC Build for the current patch line before finalizing."
+          if ($rcState.Version -ne $branchVersion) {
+            Write-Error "Latest RC candidate for '$releaseBranch' exposes version '$($rcState.Version)', but the branch base version is '$branchVersion'. Fix the RC channel metadata before running Release Finalize."
             exit 1
           }
           if (-not $rcState.Commit -or $rcState.Commit -notmatch '^[0-9a-f]{40}$') {
@@ -254,33 +259,33 @@ jobs:
           }
 
           $selectedCommit = $rcState.Commit
-          $packageVersion = $rcState.PackageVersion
+          $sourcePackageVersion = $rcState.PackageVersion
           $sourceMode = "latest_rc_candidate"
           $sourceLabel = $rcState.TagName
+          $expectedSourceVersion = $branchVersion
         }
 
-        $packagePattern = '^' + [regex]::Escape($version) + '\.(?<build>\d+)$'
-        $packageMatch = [regex]::Match($packageVersion, $packagePattern)
+        $packagePattern = '^' + [regex]::Escape($expectedSourceVersion) + '\.(?<build>\d+)$'
+        $packageMatch = [regex]::Match($sourcePackageVersion, $packagePattern)
         if (-not $packageMatch.Success) {
-          Write-Error "Selected package version '$packageVersion' does not match target version '$version'."
+          Write-Error "Selected source package version '$sourcePackageVersion' does not match expected source version '$expectedSourceVersion'."
           exit 1
         }
 
         $build = [int]$packageMatch.Groups['build'].Value
-        if ($build -le 0 -or $build -gt 65535) {
-          Write-Error "Selected package version '$packageVersion' resolved invalid build '$build'."
-          exit 1
-        }
+        $packageVersion = "$version.$build"
 
         echo "BRANCH_HEAD_COMMIT=$branchHeadCommit" >> $env:GITHUB_OUTPUT
         echo "SELECTED_COMMIT=$selectedCommit" >> $env:GITHUB_OUTPUT
         echo "PACKAGE_VERSION=$packageVersion" >> $env:GITHUB_OUTPUT
+        echo "SOURCE_PACKAGE_VERSION=$sourcePackageVersion" >> $env:GITHUB_OUTPUT
         echo "BUILD=$build" >> $env:GITHUB_OUTPUT
         echo "SOURCE_MODE=$sourceMode" >> $env:GITHUB_OUTPUT
         echo "SOURCE_LABEL=$sourceLabel" >> $env:GITHUB_OUTPUT
         Write-Host "Branch HEAD commit: $branchHeadCommit"
         Write-Host "Selected source commit: $selectedCommit"
-        Write-Host "Selected package version: $packageVersion"
+        Write-Host "Selected source package version: $sourcePackageVersion"
+        Write-Host "Finalized package version: $packageVersion"
         Write-Host "Selected build: $build"
         Write-Host "Selected source mode: $sourceMode ($sourceLabel)"
 
@@ -397,7 +402,7 @@ jobs:
         }
 
         if ($tagCommit -ne $storeSubmissionCommit) {
-          Write-Error "Version tag '$version' points to '$tagCommit', but Store submission status '$storeSubmissionStatus' already locked this version to '$storeSubmissionCommit'. Start the next patch cycle instead of retagging '$version'."
+          Write-Error "Version tag '$version' points to '$tagCommit', but Store submission status '$storeSubmissionStatus' already locked this version to '$storeSubmissionCommit'. Choose a newer finalized patch line instead of retagging '$version'."
           exit 1
         }
         if ($archivePackageVersion -and $archivePackageVersion -ne $packageVersion) {
@@ -429,9 +434,9 @@ jobs:
         if ($blockingFiles.Count -gt 0) {
           $blockingList = $blockingFiles -join ", "
           if ($hasStoreSubmission) {
-            Write-Error "Selected release branch HEAD is ahead of Store-submitted version tag '$version' with product-affecting changes: $blockingList. The tag is fixed after Store submission; start the next patch cycle instead of retagging '$version'."
+            Write-Error "Selected release branch HEAD is ahead of Store-submitted version tag '$version' with product-affecting changes: $blockingList. The tag is fixed after Store submission; choose a newer finalized patch line instead of retagging '$version'."
           } else {
-            Write-Error "Selected release branch HEAD is ahead of version tag '$version' with product-affecting changes: $blockingList. Re-run with create_version_tag=true to retarget '$version' before Store submission, or start the next patch cycle."
+            Write-Error "Selected release branch HEAD is ahead of version tag '$version' with product-affecting changes: $blockingList. Re-run with create_version_tag=true to retarget '$version' before Store submission, or choose a newer finalized patch line."
           }
           exit 1
         }
@@ -458,7 +463,7 @@ jobs:
         }
         echo "Verified release branch: $branch"
 
-    - name: Verify Release Finalize target is current patch line
+    - name: Verify Release Finalize target is not older than latest finalized version
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
@@ -615,9 +620,9 @@ jobs:
       shell: pwsh
       run: |
         [xml]$props = Get-Content Directory.Build.props
-        $version = $props.Project.PropertyGroup.Version
-        if ($version -ne "${{ steps.target.outputs.VERSION }}") {
-          Write-Error "Version mismatch: Directory.Build.props has $version but resolved tag is ${{ steps.target.outputs.VERSION }}"
+        $version = ([string]$props.Project.PropertyGroup.Version).Trim()
+        if ($version -ne "${{ steps.target.outputs.BRANCH_VERSION }}") {
+          Write-Error "Version mismatch: Directory.Build.props has $version but release branch base version is ${{ steps.target.outputs.BRANCH_VERSION }}"
           exit 1
         }
 
@@ -633,10 +638,6 @@ jobs:
         $match = [regex]::Match($version, '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$')
         if (-not $match.Success) {
           Write-Error "Invalid version format: $version (expected X.Y.Z)"
-          exit 1
-        }
-        if ($build -le 0 -or $build -gt 65535) {
-          Write-Error "Invalid build number: $build (expected 1..65535)"
           exit 1
         }
 
@@ -860,17 +861,19 @@ jobs:
         | **Version** | `{0}` |
         | **Release Branch** | `{1}` |
         | **Checkout Ref** | `{2}` |
-        | **InformationalVersion** | `{3}` |
-        | **FileVersion** | `{4}` |
-        | **Package Version** | `{5}` |
+        | **Source Package Version** | `{3}` |
+        | **InformationalVersion** | `{4}` |
+        | **FileVersion** | `{5}` |
+        | **Package Version** | `{6}` |
         | **Signing** | `unsigned (verification archive)` |
         | **Checksum** | `SHA256SUMS.txt` |
         | **Provenance** | `GitHub Artifact Attestation` |
-        | **Commit** | [`{6}`]({7}/{8}/commit/{6}) |
-        | **Build** | [#{9}]({7}/{8}/actions/runs/{10}) |
+        | **Commit** | [`{7}`]({8}/{9}/commit/{7}) |
+        | **Build** | [#{10}]({8}/{9}/actions/runs/{11}) |
 
-        > This GitHub Release keeps the selected verification archive for the current patch line. Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` with the same `patch` adopts the latest successful RC candidate and may replace the selected build. After Store submission is recorded, the selected build is treated as fixed.
-        '@ -f $version, $releaseBranch, $checkoutRef, $informationalVersion, $fileVersion, $msixVersion, $commitSha, $serverUrl, $repository, $runNumber, $runId
+        > `release/X.Y` keeps repository version `X.Y.0`, so the selected RC candidate may expose source package version `X.Y.0.B` even when the finalized archive package becomes `X.Y.Z.B`.
+        > Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` with the same `patch` adopts the latest successful RC candidate and may replace the selected build. After Store submission is recorded, the selected build is treated as fixed.
+        '@ -f $version, $releaseBranch, $checkoutRef, "${{ steps.selected_source.outputs.SOURCE_PACKAGE_VERSION }}", $informationalVersion, $fileVersion, $msixVersion, $commitSha, $serverUrl, $repository, $runNumber, $runId
         }
         $archiveSection = $archiveSection.Trim()
 
@@ -1077,28 +1080,30 @@ jobs:
         | Version | `{0}` |
         | Release Branch | `{1}` |
         | Checkout Ref | `{2}` |
-        | InformationalVersion | `{3}` |
-        | FileVersion | `{4}` |
-        | Package Version | `{5}` |
-        | Release Title | `{6}` |
-        | Prerelease | `{7}` |
-        | Release Notes | [`{8}`]({9}) |
-        | Version Tag State | `{10}` |
-        | Store Lock | `{11}` |
-        | Archive Mode | `{12}` |
-        | Release Archive Artifact | `{13}` |
-        | Store Package Mode | `{14}` |
-        | Store Artifact | `{15}` |
+        | Source Package Version | `{3}` |
+        | InformationalVersion | `{4}` |
+        | FileVersion | `{5}` |
+        | Package Version | `{6}` |
+        | Release Title | `{7}` |
+        | Prerelease | `{8}` |
+        | Release Notes | [`{9}`]({10}) |
+        | Version Tag State | `{11}` |
+        | Store Lock | `{12}` |
+        | Archive Mode | `{13}` |
+        | Release Archive Artifact | `{14}` |
+        | Store Package Mode | `{15}` |
+        | Store Artifact | `{16}` |
         | Checksum | `SHA256SUMS.txt` |
         | Provenance | `GitHub Artifact Attestation` |
-        | Commit SHA | `{16}` |
-        | Build | [#{17}]({18}/{19}/actions/runs/{20}) |
+        | Commit SHA | `{17}` |
+        | Build | [#{18}]({19}/{20}/actions/runs/{21}) |
 
-        `Release Notes` keeps a stable link to the release-line issue search, and `Operator Notes` / `Store Submission Log` are preserved across reruns. Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` for the same `patch` adopts the latest successful RC candidate and can replace the selected archive build. After Store submission is recorded, the selected build is fixed.
+        `Release Notes` keeps a stable link to the release-line issue search, and `Operator Notes` / `Store Submission Log` are preserved across reruns. `release/X.Y` itself stays on repository version `X.Y.0`; `Release Finalize` alone rewrites the patch segment from the selected RC source package to the finalized archive/store package. Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` for the same `patch` adopts the latest successful RC candidate and can replace the selected archive build. After Store submission is recorded, the selected build is fixed.
         '@ -f `
           "${{ steps.version.outputs.VERSION }}", `
           "${{ steps.source.outputs.RELEASE_BRANCH }}", `
           "${{ steps.tag.outputs.CHECKOUT_REF }}", `
+          "${{ steps.selected_source.outputs.SOURCE_PACKAGE_VERSION }}", `
           "${{ steps.version.outputs.INFORMATIONAL_VERSION }}", `
           "${{ steps.version.outputs.FILE_VERSION }}", `
           "${{ steps.version.outputs.MSIX_VERSION }}", `

--- a/docs/distribution/ArtifactInstallation.md
+++ b/docs/distribution/ArtifactInstallation.md
@@ -48,9 +48,9 @@ RC を導入する場合は `-Channel rc -SourceRef refs/heads/release/X.Y`、�
 
 Dev / RC / Archive は `ClipSave.Preview` identity で配布され、Store 版とは別パッケージとして扱われます。Store 版と Preview 版は共存できますが、設定や LocalState は共有されません。
 
-Dev（例: `0.0.1.42`）と RC / Archive（例: `0.1.3.57`）は version line が異なるため、channel を切り替えると Preview identity 内で上書き導入できないことがあります。必要に応じて先に既存 Preview package をアンインストールしてください。
+Dev（例: `0.0.1.42`）と RC / Archive（例: RC=`0.1.0.57`, Archive=`0.1.3.57`）は version line が異なるため、channel を切り替えると Preview identity 内で上書き導入できないことがあります。必要に応じて先に既存 Preview package をアンインストールしてください。
 
-RC 候補同士は build 番号が増えていれば通常は上書き導入できますが、古い build へ戻す場合や、RC 候補から同じ build を採用した Archive（`X.Y.Z.B`）へ切り替える場合は、同一 Preview identity / 同一 package version のため上書き導入できないことがあります。必要に応じて既存の Preview パッケージを削除してから導入してください。
+RC 候補同士は build 番号が増えていれば通常は上書き導入できます。RC 候補から同じ build を採用した Archive へ切り替える場合、初回 `X.Y.0` finalize では同一 package version のため上書き導入できないことがあります。`Z>0` の patch finalize では archive `X.Y.Z.B` が RC `X.Y.0.B` より新しいため、通常は上書き導入できます。古い build へ戻す場合は、必要に応じて既存の Preview パッケージを削除してから導入してください。
 
 確定タグ `X.Y.Z` に対応するアーカイブ版は Store 公開の有無と独立しているため、試験リリースも同じ手順で導入できます。
 GitHub Release 側で `prerelease` 表示になっていても、導入手順や真正性確認の方法は変わりません。

--- a/docs/distribution/store/StoreSubmission.md
+++ b/docs/distribution/store/StoreSubmission.md
@@ -24,7 +24,8 @@
 - 対象版が [../../release/ReleaseProcess.md](../../release/ReleaseProcess.md) の Store チャネル進行条件を満たしている。
 - [../../release/ReleaseGuide.md](../../release/ReleaseGuide.md) に従って `Release Finalize` の Store package mode が成功している。
 - workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Package Version=X.Y.Z.B`、`Store Package Mode=built` を確認できる。
-- 同じ run の `store-package-X.Y.Z` artifact から `.msixupload` を取得でき、workflow の Store identity 検証も通っている。GitHub Release `X.Y.Z` assets は使わない。
+- 必要に応じて workflow summary の `Source Package Version` を確認し、source RC candidate が `X.Y.0.B` から finalize されたことを理解している。
+- 同じ run の `store-package-X.Y.Z` artifact から `.msixupload` を取得でき、workflow の Store identity 検証も通っている。
 
 ## 提出手順
 
@@ -38,8 +39,9 @@
 
 ## 提出前チェックリスト
 
-- `store-package-X.Y.Z` artifact から `.msixupload` を取得済みであること。GitHub Release assets は使わない。
+- `store-package-X.Y.Z` artifact から `.msixupload` を取得済みであること。
 - workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Package Version=X.Y.Z.B`、`Store Package Mode=built` を確認済みであること。
+- 必要に応じて workflow summary の `Source Package Version` を確認し、source RC candidate が `X.Y.0.B` から finalize されたことを理解していること。
 - `Privacy policy URL` に公開済みの [../../../PRIVACY.md](../../../PRIVACY.md) 相当ページを設定し、`Support contact` が設定済みであること。
 - listing CSV の必須項目（`Title`、`ShortDescription`、`ReleaseNotes`、`DesktopScreenshot1`）に空欄がないこと。
 - package upload 後に `制限付き機能` セクションが表示された場合は、`runFullTrust` の利用理由を記入済みであること。表示されない場合は、同内容を `審査向け補足` に記入済みであること。
@@ -86,7 +88,7 @@ Store policy 上、Desktop Bridge / Win32 製品は privacy policy が必須に�
 | 生成方法 | `.github/workflows/release-finalize.yml` |
 | workflow 実行 | GitHub Actions で `release/X.Y` を選択して実行 |
 | workflow 入力 | `patch` に対象の `Z` を入れる（初回 `X.Y.0` リリースは `patch=0`）。通常は `build_store_package=true` / `create_version_tag=true` のまま実行 |
-| 対象バージョン | `X.Y.Z.B`（`B > 0`。`B` は対象 `release/X.Y` branch の RC カウンター） |
+| 対象バージョン | finalized package version は `X.Y.Z.B`（source RC candidate は `X.Y.0.B` のままでもよい） |
 | 対象デバイス | `Windows.Desktop` を確認 |
 
 ### ストア登録情報（Listing）

--- a/docs/release/ReleaseGuide.md
+++ b/docs/release/ReleaseGuide.md
@@ -26,16 +26,14 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 
 補足:
 
-- patch 開始に専用 workflow は使わない。`release/X.Y` 向け PR で `PATCH` を更新する。
-- `main` を次系列へ進める bump PR は作らない。
-- Dev 配布版の package version は `0.0.1.B`、RC / Archive / Store 配布版は `X.Y.Z.B` を使う。
+- patch line `Z` は `Release Finalize` で決め、修正 PR は `release/X.Y` へ反映する。
+- Dev 配布版の package version は `0.0.1.B`、RC は `X.Y.0.B`、Archive / Store は `X.Y.Z.B` を使う。
 - RC の `B` は `release/X.Y` branch ごとのカウンターで、新しい release branch を切ると 1 から始まる。
-- `B=0` は配布版に使わない。
-- `main=0.0.1` を preview line として固定し、release branch の `X.Y.Z` と配布 version line を分けることで、Dev と RC / Archive / Store の役割を見分けやすくする。
+- `main=0.0.1` を preview line として固定し、release branch の `X.Y.0` base version と finalized version line `X.Y.Z` を分けることで、Dev と RC / Archive / Store の役割を見分けやすくする。
 - `AssemblyVersion` は配布 build 識別子ではなく互換性用に扱い、実際の配布物識別は `FileVersion` / package version / `InformationalVersion` で行う。
 - `dev-latest` / `rc-X.Y-latest` は floating tag として、docs-only を含む各 branch の最新 commit に追随させる。
 - `rc-X.Y-latest` の GitHub Release は候補版として常に `prerelease` 表示にする。
-- `Release Finalize` は現行サポート系列の current patch line に対してだけ実行し、過去 patch line や旧系列の補修には使わない。
+- `Release Finalize` は現行サポート系列で、同じ finalized version の rerun または新しい patch line の確定に使う。
 - `Release Finalize` の build は手動指定せず、Store 提出前は `rc-X.Y-latest` の最新成功候補を自動採用する。
 - `Release Finalize` の `patch` 入力は `X.Y.Z` の `Z` を指す。メジャー / マイナー系列の初回 finalize は `patch=0`、以後の patch release は対象の `Z` を入れる。
 
@@ -51,7 +49,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 | チャネル | 配布元 | 用途 |
 | ---- | ---- | ---- |
 | Dev | `dev-latest` / `dev-package-*` + `SHA256SUMS.txt` | 検証配布（未署名、package version=`0.0.1.B`） |
-| RC | `rc-X.Y-latest` / `rc-package-*` + `SHA256SUMS.txt` | 公開候補比較（未署名、package version=`X.Y.Z.B`） |
+| RC | `rc-X.Y-latest` / `rc-package-*` + `SHA256SUMS.txt` | 公開候補比較（未署名、package version=`X.Y.0.B`） |
 | Archive | GitHub Release `X.Y.Z` / `release-archive-*` + `SHA256SUMS.txt` | 確定 build の固定配布 / 再検証（未署名、package version=`X.Y.Z.B`） |
 | Store | `store-package-*`（`.msixupload`） | Partner Center 提出 |
 
@@ -64,7 +62,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 
 1. `Release Finalize` の成功を確認し、GitHub Release `X.Y.Z` に `*.msixbundle` と `SHA256SUMS.txt` が揃っていること、同じ workflow 実行に対する GitHub Artifact Attestation が `gh attestation verify` で検証可能であることを確認する。
 2. Store 提出対象の `.msixupload` は GitHub Release assets ではなく、同じ run の `store-package-*` artifact から取得する。
-3. Store 提出前に追加修正や archive の差し替えが必要になった場合は、同じ current patch line に対して `Release Finalize` を `release/X.Y` から手動再実行し、対象の `patch=Z` を指定する。最新成功 RC 候補は自動採用される。
+3. Store 提出前に追加修正や archive の差し替えが必要になった場合は、同じ finalized version `X.Y.Z` に対して `Release Finalize` を `release/X.Y` から手動再実行し、対象の `patch=Z` を指定する。最新成功 RC 候補は自動採用される。
 4. `Release Notes: X.Y` を更新しただけなら `Release Finalize` の再実行は不要。GitHub Release は issue 参照だけを持つ。
 5. Store へ進める条件は [ReleaseProcess](ReleaseProcess.md) の「Store チャネルへの進行条件」を正本とし、条件を満たす場合のみ `Release Finalize` で Store package を作成する。
 6. Partner Center へ提出したら、[StoreSubmission](../distribution/store/StoreSubmission.md) に従って `Store Submission Log` を GitHub Release に記録する。ここで採用 commit が固定化される。
@@ -76,26 +74,26 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 3. `Prepare Release` が `Release Notes: X.Y` Issue を自動作成または再利用する。手元スクリプトだけを使う場合は手動で作成または更新する。
 4. `Release Notes: Unreleased` から今回の系列で出す bullet を `Release Notes: X.Y` へ手動で移す。
 5. `release/X.Y` の安定化を PR で反映する。
-6. `rc-X.Y-latest` と必要な RC 成果物を確認し、採用したい候補が latest RC として見えていることを確認する。
-7. `Release Notes: X.Y` Issue を見直し、今回の出荷内容として読めるよう公開向け文面を整える。
-8. `Release Finalize` を `release/X.Y` から実行し、初回リリースでは `patch=0` を指定して GitHub Release `X.Y.0` と archive / Store package を揃える。
-9. Store 提出前に別候補を採用し直す必要が出た場合は、release branch を更新して RC Build を通し、同じ patch line `X.Y.Z` に対して `Release Finalize` を再実行する。
-10. Store 提出は [../distribution/store/StoreSubmission.md](../distribution/store/StoreSubmission.md) の手順に従って実行し、提出直後に `Store Submission Log` を記録する。
+6. `release/X.Y` の repository version は `X.Y.0` とする。
+7. `rc-X.Y-latest` と必要な RC 成果物を確認し、採用したい候補が latest RC として見えていることを確認する。
+8. `Release Notes: X.Y` Issue を見直し、今回の出荷内容として読めるよう公開向け文面を整える。
+9. `Release Finalize` を `release/X.Y` から実行し、初回リリースでは `patch=0` を指定して GitHub Release `X.Y.0` と archive / Store package を揃える。
+10. Store 提出前に別候補を採用し直す必要が出た場合は、release branch を更新して RC Build を通し、同じ patch line `X.Y.Z` に対して `Release Finalize` を再実行する。
+11. Store 提出は [../distribution/store/StoreSubmission.md](../distribution/store/StoreSubmission.md) の手順に従って実行し、提出直後に `Store Submission Log` を記録する。
 
 ### パッチリリース
 
 対象は [ReleaseProcess](ReleaseProcess.md) で定義した現行サポート系列のみとする。
 
-1. `release/X.Y` 向けの通常 PR で `PATCH` を `X.Y.(Z+1)` へ更新する。patch 開始専用 workflow は使わない。
-2. `PATCH` 更新 PR をマージする。
-3. 不具合修正を `main` へマージする。
-4. `release/X.Y` をベースにした `fix/*` backport ブランチで必要コミットを `cherry-pick -x` し、PR で `release/X.Y` へ反映する。
-5. `rc-X.Y-latest` と必要な RC 成果物を確認し、採用したい候補が latest RC として見えていることを確認する。
-6. tag 前に `Release Notes: X.Y` Issue を見直し、今回の patch 版として読めるよう公開向け文面を整える。
-7. `Release Finalize` を `release/X.Y` から実行し、対象の `patch=Z+1` を指定する。
-8. GitHub Release `X.Y.(Z+1)` に archive 成果物が保存されたことを確認する。
-9. Store 提出前に追加修正が必要になった場合は、release branch を更新して RC Build を通し、同じ patch line に対して `Release Finalize` を再実行する。
-10. Store へ進める条件を満たす場合のみ、Store package を生成して提出する。
+1. 不具合修正を `main` へ PR で反映する。
+2. `release/X.Y` をベースにした `fix/*` backport ブランチで必要コミットを `cherry-pick -x` し、PR で `release/X.Y` へ反映する。
+3. `release/X.Y` の repository version は `X.Y.0` とする。
+4. `rc-X.Y-latest` と必要な RC 成果物を確認し、採用したい候補が latest RC として見えていることを確認する。
+5. `Release Finalize` 前に `Release Notes: X.Y` Issue を見直し、今回の patch 版として読めるよう公開向け文面を整える。
+6. `Release Finalize` を `release/X.Y` から実行し、operator が採番した対象 `patch=Z` を指定する。
+7. GitHub Release `X.Y.Z` に archive 成果物が保存され、workflow summary で source package version が `X.Y.0.B`、final package version が `X.Y.Z.B` になっていることを確認する。
+8. Store 提出前に追加修正が必要になった場合は、release branch を更新して RC Build を通し、同じ patch line `X.Y.Z` に対して `Release Finalize` を再実行する。
+9. Store へ進める条件を満たす場合のみ、Store package を生成して提出する。
 
 ### Store 提出
 
@@ -109,7 +107,7 @@ Partner Center への upload、listing CSV import、審査向け補足、submiss
 1. 問題のある配布リンクを停止または更新する。
 2. `main`（必要なら `release/X.Y`）へ復旧 PR を反映する。
 3. 修正版を再ビルドして差し替える。
-4. GitHub Release `X.Y.Z` に紐づく archive build に問題がある場合は削除せず、現行サポート系列の current patch line かつ Store 提出前であれば release branch を更新して RC Build を通し、`Release Finalize` を再実行して latest RC 候補へ差し替える。条件を外れる場合は次の patch line を作る。
+4. GitHub Release `X.Y.Z` に紐づく archive build に問題がある場合は削除せず、現行サポート系列かつ Store 提出前であれば release branch を更新して RC Build を通し、同じ `patch=Z` で `Release Finalize` を再実行して latest RC 候補へ差し替える。条件を外れる場合は新しい patch line を finalize する。
 
 ### Store 提出後
 

--- a/docs/release/ReleaseNotes.md
+++ b/docs/release/ReleaseNotes.md
@@ -67,11 +67,11 @@ Issue title: `Release Notes: Unreleased`
 
 ### release line 運用中
 
-1. `main` 側の user-facing change は引き続き `Release Notes: Unreleased` を更新する。
+1. `main` 側の user-facing change は `Release Notes: Unreleased` を更新する。
 2. `release/X.Y` 側の安定化 PR / backport PR は、必要に応じて `Release Notes: X.Y` を更新する。
 3. `Release Notes: X.Y` は、その系列で次に出す版の候補を保持する。
 
-### tag 前
+### Release Finalize 前
 
 1. `Release Notes: X.Y` Issue を見直し、今回の出荷内容として読めることを確認する。
 2. 必要なら merged PR や関連 Issue を見て bullet を補い、ユーザー向け文面に磨く。
@@ -83,7 +83,7 @@ Issue title: `Release Notes: Unreleased`
 3. GitHub Release 本文には `Release Notes: X.Y` への参照が入る。
 4. issue が未整備のままでも release 自体は作成されるが、Store 前確認では未整備として扱う。
 5. Store 提出前に `Release Finalize` を `release/X.Y` から手動再実行する場合は、同じ patch line に対して対象の `patch=Z` を指定する。build は `rc-X.Y-latest` の最新成功候補から自動解決される。
-6. GitHub Release `X.Y.Z` は patch line を表し、archive / Store package は採用した latest RC build `X.Y.Z.B` に揃える。
+6. GitHub Release `X.Y.Z` は patch line を表し、selected RC source package は `X.Y.0.B` のままでも、archive / Store package は finalized version `X.Y.Z.B` に揃える。
 7. Store 提出後は `Store Submission Log` の記録をもって採用 commit が固定化されるため、再実行しても採用 build は勝手に差し替えない。
 8. issue 本文を更新しただけなら rerun は不要。再実行は GitHub Release 側の更新や archive 補完が必要な場合だけでよい。
 9. GitHub Release 本文は、配布案内を主としたシンプルな構成を保つ。

--- a/docs/release/ReleaseProcess.md
+++ b/docs/release/ReleaseProcess.md
@@ -29,8 +29,8 @@
 flowchart LR
   main[main] -->|Dev Build| dev[dev-latest / dev-package-0.0.1.B]
   main -->|Prepare Release| release[release/X.Y]
-  release -->|RC Build| rc[rc-X.Y-latest / rc-package-X.Y.Z.B]
-  release -->|patch version PR| release
+  release -->|RC Build| rc[rc-X.Y-latest / rc-package-X.Y.0 / package X.Y.0.B]
+  release -->|stabilize/backport PR| release
   release -->|Release Finalize patch=Z| tag[tag X.Y.Z]
   tag --> archive[GitHub Release X.Y.Z / release-archive-X.Y.Z.B]
   tag --> store[store-package-X.Y.Z.B]
@@ -39,16 +39,14 @@ flowchart LR
 ## 基本モデル
 
 1. 開発の正本は常に `main` とする。
-2. `main` の repository version は固定で `0.0.1` とし、release 準備のたびに version bump しない。
-3. `release/X.Y` の repository version は `X.Y.Z` とし、`PATCH` がその系列の公開順序を表す。
+2. `main` の repository version は `0.0.1` とする。
+3. `release/X.Y` の repository version は常に `X.Y.0` とし、patch line `Z` は branch ではなく `Release Finalize` の手動入力で決める。
 4. 配布物の package / file version は 4 桁とし、4 桁目 `B` を build 番号として使う。
 5. Dev の配布版は MSIX 都合のため予約済み preview line `0.0.1.B` を使う。
-6. RC / Archive / Store の配布版は `X.Y.Z.B` を使い、`B` は `release/X.Y` ごとの `rc-build` カウンターを採用する。
+6. RC の配布版は `X.Y.0.B`、Archive / Store の配布版は `X.Y.Z.B` を使い、`B` は `release/X.Y` ごとの `rc-build` カウンターを採用する。
 7. `release/X.Y` を新しく作ると、その branch の `B` は 1 から数え直す。
-8. `B=0` は配布版として使わない。`.0` を確定版にする運用はやめる。
-9. version tag は引き続き `X.Y.Z` とし、GitHub Release `X.Y.Z` は patch line を表す。
-10. `Release Finalize` は branch 上の現在値を暗黙採用するのではなく、選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、`rc-X.Y-latest` の最新成功候補から `build=B` を自動採用して archive / Store package を揃える。
-11. `Prepare Release` による main bump PR と、patch 開始専用 workflow は廃止する。
+8. version tag は `X.Y.Z` とし、GitHub Release `X.Y.Z` は patch line を表す。
+9. `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、`rc-X.Y-latest` の最新成功候補から `build=B` を採用して archive / Store package を揃える。
 
 ## ブランチモデル
 
@@ -95,27 +93,26 @@ flowchart LR
 ### 1. Prepare
 
 - `main` から `release/X.Y` を作成する。
-- `release/X.Y` 側だけを対象系列の `X.Y.Z` へ進める。
-- `main` は `0.0.1` のまま維持する。release 準備で main bump PR は作らない。
+- `release/X.Y` 側だけを対象系列の `X.Y.0` に設定する。
+- `main` は `0.0.1` を維持する。
 
 ### 2. Stabilize
 
 - `release/X.Y` では新機能開発を行わず、安定化と必要な修正だけを扱う。
 - 候補比較には `rc-X.Y-latest` と RC 成果物を使う。
-- RC の package version は `X.Y.Z.B` とし、`B` は同じ `release/X.Y` branch の中で build ごとに増える。
+- RC の package version は `X.Y.0.B` とし、`B` は同じ `release/X.Y` branch の中で build ごとに増える。
 - 新しい `release/X.Y` を切ると、その branch の `B` は 1 から始まる。
 
 ### 3. Finalize
 
-- 確定対象は、その時点の現行サポート patch line と、その patch line に対する最新成功 RC build `X.Y.Z.B` の組で決める。
-- `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version` を解決し、Store 提出前は `rc-X.Y-latest` の最新成功候補を採用して tag / archive / Store package を揃える。
-- 4 桁目 `B=0` は無効とし、配布版には使わない。
+- 確定対象は、operator が選ぶ patch line `X.Y.Z` と、その時点の最新成功 RC build `X.Y.0.B` の組で決める。
+- `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、Store 提出前は `rc-X.Y-latest` の最新成功候補 `X.Y.0.B` を採用して tag / archive / Store package `X.Y.Z.B` を揃える。
 - Store 提出前の手動再実行では、同じ patch line に対して `patch=Z` を指定し、その時点の最新成功 RC 候補を採用して archive / Store package を差し替えてよい。
 - Store 提出記録後は、その patch line の採用 commit を固定とする。
 
 ### 4. Distribute
 
-- Archive: GitHub Release `X.Y.Z` に、採用した最新成功 RC build の archive（`X.Y.Z.B`）を保持する。
+- Archive: GitHub Release `X.Y.Z` に、採用した最新成功 RC build を finalize した archive（`X.Y.Z.B`）を保持する。
 - Store: 一般ユーザー向けに出す版だけ、`Release Finalize` から Store package を生成する。
 - Store 公開の有無は finalized 判定に影響させないが、採用 commit 固定の境界は `Store Submission Log` 記録時点とする。
 
@@ -123,7 +120,7 @@ flowchart LR
 
 - ClipSave は latest-only 運用とし、能動サポート対象は常に最新 finalized 系列 1 つのみとする。
 - 現行系列である間だけ、patch release、Store 再提出、`Release Finalize` 実行 / 再実行を通常運用として行う。
-- PR / RC を workflow で一律停止しない。hard gate は Store package 生成時だけに置く。
+- Store package 生成時だけを hard gate とし、それ以外の PR / RC 運用は継続する。
 
 ### 6. End of support
 
@@ -135,7 +132,7 @@ flowchart LR
 
 - 切替基準は Store 公開有無ではなく Finalize 完了とする。
 - 新系列を archive-only で Finalize した場合でも、その時点で旧系列はサポート対象から外れる。
-- `Release Finalize` の実行対象も、現行サポート系列の current patch line のみに限定する。
+- `Release Finalize` の実行対象も、現行サポート系列に対する同一 finalized version の rerun または新しい patch line の確定に限定する。
 - 同一系列内でも Store package mode を許可するのは、最新 finalized patch line のみとする。
 
 ## Store チャネルへの進行条件
@@ -162,20 +159,19 @@ flowchart LR
 | 文脈 | repository 上の版数 | 配布時の package / file version | 用途 |
 | ---- | ---- | ---- | ---- |
 | `main` | `0.0.1` | `0.0.1.B` | Dev preview line |
-| `release/X.Y` | `X.Y.Z` | `X.Y.Z.B` | RC / Archive / Store |
+| `release/X.Y` | `X.Y.0` | RC=`X.Y.0.B` / Archive, Store=`X.Y.Z.B` | 現行系列サポート |
 
 補足:
 
 - `Directory.Build.props` の `Version` は repository 上では常に 3 桁とする。
 - `Package.appxmanifest` は repository 上では `Version.0` を保持する。
 - Dev / RC / Archive / Store の 4 桁目 `B` は CI / finalize 時に注入し、repository にはコミットしない。
-- `B` は正の整数とし、配布 build に `0` は使わない。
 - RC の `B` は branch ごとのカウンターであり、`release/0.1` と `release/0.2` では独立して数える。
 
 なぜこの運用にするか:
 
-- `main` を `0.0.1` に固定するのは、Dev を常に preview line として識別し、安定化対象の `release/X.Y` が持つ `X.Y.Z` と混同しないため。
-- Dev を `0.0.1.B`、RC / Archive / Store を `X.Y.Z.B` に分けるのは、Preview チャネルと release-line 候補を version line だけで見分けられるようにし、patch line ごとの採用判断を単純化するため。
+- `main` を `0.0.1` に固定するのは、Dev を常に preview line として識別し、安定化対象の `release/X.Y` が持つ `X.Y.0` base version や finalized version `X.Y.Z` と混同しないため。
+- Dev を `0.0.1.B`、RC を `X.Y.0.B`、Archive / Store を `X.Y.Z.B` に分けるのは、release branch の repository version を PR ごとに動かさず、Finalize だけが patch line を確定する責務分離にするため。
 - `AssemblyVersion` は CLR の互換性軸として固定寄りに扱い、配布 build の識別責務は `FileVersion` / package version / `InformationalVersion` に寄せる。Dev で `0.0.0.0`、release 系で `X.Y.0.0` を使うのはこのため。
 
 ### タグ種別
@@ -195,8 +191,8 @@ flowchart LR
 | 場面 | 判定情報 | ルール |
 | ---- | ---- | ---- |
 | Dev 配布物 | package / file version | `0.0.1.B` を使う |
-| RC / Archive / Store 配布物 | package / file version | `X.Y.Z.B` を使う |
-| 配布 build の有効性 | 4 桁目 `B` | `B > 0` 必須 |
+| RC 配布物 | package / file version | `X.Y.0.B` を使う |
+| Archive / Store 配布物 | package / file version | `X.Y.Z.B` を使う |
 | 配布物 | 配布チャネル | `rc-X.Y-latest` は最新候補、GitHub Release `X.Y.Z` は patch line 用の archive 窓口 |
 
 ### 検証ルール
@@ -206,7 +202,7 @@ flowchart LR
 1. `Directory.Build.props` が `X.Y.Z` 形式
 2. `Package.appxmanifest` が `X.Y.Z.0` 形式
 3. 両者の `X.Y.Z` が一致
-4. `release/X.Y` ではブランチ名と版数の `X.Y` が一致
+4. `release/X.Y` ではブランチ名と版数の `X.Y` が一致し、repository version の patch は常に `0`
 
 補足:
 
@@ -224,17 +220,16 @@ flowchart LR
 ### メジャー / マイナー開始
 
 - `Prepare Release` は explicit な `X.Y` を入力として `release/X.Y` を作成する。
-- `release/X.Y` 作成後も `main` は `0.0.1` のまま維持する。
-- main を次系列へ進めるための bump PR は作らない。
+- `release/X.Y` 作成後も `main` は `0.0.1` を維持する。
 
 ### パッチリリース
 
 - patch release は現行サポート系列でのみ行う。
-- 前回の patch line が `X.Y.Z` なら、次回は `X.Y.(Z+1)` とする。
-- `PATCH` を上げるのは `release/X.Y` 向けの通常 PR とし、専用の patch init workflow は使わない。
-- `PATCH` 更新 PR がマージされた後、RC Build が `X.Y.(Z+1).B` を発行する。
+- patch release 用 PR でも `release/X.Y` の repository version は `X.Y.0` のまま維持する。
+- 修正は `main` に入れてから必要分を `release/X.Y` へ backport し、version files は変えない。
+- RC Build は常に branch base version `X.Y.0.B` を発行する。
 - `B` はその `release/X.Y` branch で継続し、新しい release branch を切るとリセットされる。
-- finalize では、その時点の `release/X.Y` が持つ patch line に対して、`rc-X.Y-latest` の最新成功候補を自動採用する。
+- finalize では、operator が選ぶ `patch=Z` に対して、`rc-X.Y-latest` の最新成功候補を自動採用する。
 
 ### Dev Build
 
@@ -246,9 +241,9 @@ flowchart LR
 Dev / RC / Archive は Store 版と別の unsigned 用 Identity（`Identity Name` / `Publisher`）を採用する。
 
 - unsigned 用 Identity は `ClipSave.Preview` とし、Publisher には Unsigned marker を含める。詳細な manifest 値は `scripts/set-package-manifest.ps1` を正本とする。
-- Store 提出物は従来どおり `tnagata012.ClipSave` / `CN=6ECD54B7-8ED5-46BA-81AD-ECBC0E843959` を使う。
-- Dev は `0.0.1.B`、RC / Archive は `X.Y.Z.B` を使うため、channel をまたぐ切り替えでは上書き導入できないことがある。
-- RC 候補から同じ build を採用した Archive へ切り替える場合は、同一 package version のためアンインストールが必要になることがある。
+- Store 提出物は `tnagata012.ClipSave` / `CN=6ECD54B7-8ED5-46BA-81AD-ECBC0E843959` を使う。
+- Dev は `0.0.1.B`、RC は `X.Y.0.B`、Archive は `X.Y.Z.B` を使うため、channel をまたぐ切り替えでは上書き導入できないことがある。
+- RC 候補から同じ build を採用した Archive へ切り替える場合、初回 `X.Y.0` finalize では同一 package version のためアンインストールが必要になることがある。`Z>0` の patch finalize では通常は archive の方が新しい version になる。
 
 ## 文書の責務分担
 

--- a/scripts/assert-version-policy.ps1
+++ b/scripts/assert-version-policy.ps1
@@ -10,7 +10,7 @@
 #
 # Rules:
 # - Directory.Build.props: always X.Y.Z
-# - release/X.Y: X.Y.Z, and X.Y must match branch name
+# - release/X.Y: X.Y.0, and X.Y must match branch name
 # - Package.appxmanifest: always X.Y.Z.0
 # - CI-injected assembly metadata (InformationalVersion/FileVersion) is out of scope
 
@@ -143,8 +143,11 @@ if ($BranchName) {
             if ($branchMajor -ne $major -or $branchMinor -ne $minor) {
                 Fail "release branch name and file version mismatch. Branch=release/$branchMajor.$branchMinor, File=$coreVersion"
             }
+            if ($patch -ne 0) {
+                Fail "release branch repository version must stay X.Y.0. Branch=$BranchName, File=$coreVersion"
+            }
 
-            Write-Host "[OK] release branch validation passed" -ForegroundColor Green
+            Write-Host "[OK] release branch validation passed (base version X.Y.0)" -ForegroundColor Green
         } else {
             Write-Host "[WARN] Branch does not match main/release rules. Skipping branch-specific checks." -ForegroundColor Yellow
         }

--- a/scripts/build-store-package.ps1
+++ b/scripts/build-store-package.ps1
@@ -7,10 +7,11 @@
     Builds a Store upload package (.msixupload) locally for preflight/debugging.
     Final submission packages must be produced by the Release Finalize workflow
     in Store package mode from a release/X.Y run that resolves and checks out
-    the fixed X.Y.Z tag to preserve reproducibility.
+    the operator-selected X.Y.Z tag to preserve reproducibility.
 
 .PARAMETER Version
-    Version to build (e.g., "1.0.0"). If not specified, reads from Directory.Build.props
+    Finalized version to build (e.g., "1.0.3"). If not specified, uses the
+    release branch base version from Directory.Build.props (X.Y.0).
 
 .PARAMETER Build
     Build number to append as the 4th segment (e.g., "57"). Defaults to 1 for local preflight.
@@ -65,17 +66,39 @@ try {
         exit 1
     }
 
-    # Get version from Directory.Build.props
+    # Get branch base version from Directory.Build.props
     [xml]$props = Get-Content "$projectRoot\Directory.Build.props"
-    $fileVersion = $props.Project.PropertyGroup.Version
-
-    # Use file version when not specified, or validate provided version
-    if (-not $Version) {
-        $Version = $fileVersion
-        Write-Host "Using version from Directory.Build.props: $Version" -ForegroundColor Cyan
-    } elseif ($Version -ne $fileVersion) {
-        Write-Error "Version mismatch: Directory.Build.props has $fileVersion but -Version is $Version"
+    $repositoryVersion = ([string]$props.Project.PropertyGroup.Version).Trim()
+    $branchMatch = [regex]::Match($currentBranch, '^release/(?<major>\d+)\.(?<minor>\d+)$')
+    if (-not $branchMatch.Success) {
+        Write-Error "Current branch is '$currentBranch'. Switch to a release branch (release/X.Y) before building Store package."
         exit 1
+    }
+
+    $branchBaseVersion = "$($branchMatch.Groups['major'].Value).$($branchMatch.Groups['minor'].Value).0"
+    if ($repositoryVersion -ne $branchBaseVersion) {
+        Write-Error "Release branch '$currentBranch' must keep repository version '$branchBaseVersion'. Actual: '$repositoryVersion'"
+        exit 1
+    }
+
+    # Use branch base version when not specified, or validate provided finalized version
+    if (-not $Version) {
+        $Version = $repositoryVersion
+        Write-Host "Using release branch base version from Directory.Build.props: $Version" -ForegroundColor Cyan
+        Write-Warning "release/X.Y keeps repository version X.Y.0. For patch releases beyond the initial X.Y.0 line, pass -Version X.Y.Z explicitly."
+    } else {
+        $requestedVersionMatch = [regex]::Match($Version, '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$')
+        if (-not $requestedVersionMatch.Success) {
+            Write-Error "Invalid version format: $Version (expected X.Y.Z)"
+            exit 1
+        }
+
+        $requestedSeries = "$($requestedVersionMatch.Groups['major'].Value).$($requestedVersionMatch.Groups['minor'].Value)"
+        $branchSeries = "$($branchMatch.Groups['major'].Value).$($branchMatch.Groups['minor'].Value)"
+        if ($requestedSeries -ne $branchSeries) {
+            Write-Error "Requested version '$Version' does not belong to current release branch '$currentBranch'."
+            exit 1
+        }
     }
 
     # Validate version format
@@ -85,10 +108,6 @@ try {
     }
 
     $versionMatch = [regex]::Match($Version, '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$')
-    if ($Build -le 0 -or $Build -gt 65535) {
-        Write-Error "Invalid build number: $Build (expected 1..65535)"
-        exit 1
-    }
 
     $segments = @(
         [int]$versionMatch.Groups['major'].Value,
@@ -122,6 +141,7 @@ try {
 
     Write-Host "`n=== Building Store Package for ClipSave v$Version (build $Build) ===" -ForegroundColor Green
     Write-Host "Branch: $currentBranch" -ForegroundColor Cyan
+    Write-Host "Release branch base version: $repositoryVersion" -ForegroundColor Cyan
     Write-Host "InformationalVersion: $informationalVersion" -ForegroundColor Cyan
     Write-Warning "This script is for local preflight only. Final submission packages must come from the Release Finalize workflow in Store package mode on the release branch."
     $msbuildPath = Resolve-MSBuildPath
@@ -261,7 +281,7 @@ try {
 
     Write-Host "`n=== Next Steps ===" -ForegroundColor Green
     Write-Host "1. Use this local package only for preflight/debugging"
-    Write-Host "2. For final submission, run Release Finalize from $currentBranch with patch=$($versionMatch.Groups['patch'].Value) (latest successful RC candidate is adopted automatically)"
+    Write-Host "2. For final submission, run Release Finalize from $currentBranch with explicit patch=$($versionMatch.Groups['patch'].Value) (the branch stays $repositoryVersion and the latest successful RC candidate is adopted automatically)"
     Write-Host "3. Confirm workflow summary shows refs/tags/$Version, Package Version=$msixVersion, Store Package Mode=built, and the expected commit SHA"
     Write-Host "4. Upload the workflow artifact .msixupload in Partner Center"
 

--- a/scripts/release-support.ps1
+++ b/scripts/release-support.ps1
@@ -638,7 +638,7 @@ function Assert-StoreSubmissionRecorded {
         throw "GitHub Release '$Version' does not have the finalized archive assets yet. Expected exactly one .msixbundle and SHA256SUMS.txt. Assets: $assetList"
     }
     if (-not $state.HasStoreSubmission) {
-        throw "GitHub Release '$Version' does not have a Store Submission Log entry yet. Record the Partner Center submission before starting the next patch cycle."
+        throw "GitHub Release '$Version' does not have a Store Submission Log entry yet. Record the Partner Center submission before selecting a newer patch line."
     }
     if (-not $state.StoreSubmissionCommit) {
         throw "GitHub Release '$Version' has a Store Submission Log entry but no parsable commit. Fix the Store Submission Log before continuing."
@@ -940,14 +940,14 @@ function Assert-ReleaseFinalizeTargetVersion {
     $latestSemVer = [Version]$latestVersion
 
     if ($targetSemVer -lt $latestSemVer) {
-        throw "Target version '$targetVersion' is older than the latest finalized version '$latestVersion'. Release Finalize is allowed only for the current patch line on the active release branch."
+        throw "Target version '$targetVersion' is older than the latest finalized version '$latestVersion'. Release Finalize cannot target an older patch line."
     }
 
     if (-not $Quiet) {
         if ($targetVersion -eq $latestVersion) {
-            Write-Host "[OK] $targetVersion is the current finalized patch line." -ForegroundColor Green
+            Write-Host "[OK] $targetVersion matches the latest finalized version and can be rerun." -ForegroundColor Green
         } else {
-            Write-Host "[OK] $targetVersion is newer than the latest finalized version '$latestVersion' and can become the next current patch line." -ForegroundColor Green
+            Write-Host "[OK] $targetVersion is newer than the latest finalized version '$latestVersion' and can become a new finalized patch line." -ForegroundColor Green
         }
     }
 

--- a/scripts/show-version-report.ps1
+++ b/scripts/show-version-report.ps1
@@ -98,12 +98,22 @@ foreach ($profile in $packageProfiles) {
 
     $packageType = "Store"
     if ($profile.Label -eq "Preview") {
-        $versionParts = $package.Version.Split('.')
-        $revision = [int]$versionParts[3]
-        if ($revision -eq 0) {
-            $packageType = "Preview (RC/Archive)"
+        $versionMatch = [regex]::Match([string]$package.Version, '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\.(?<build>\d+)$')
+        if ($versionMatch.Success) {
+            $major = [int]$versionMatch.Groups['major'].Value
+            $minor = [int]$versionMatch.Groups['minor'].Value
+            $patch = [int]$versionMatch.Groups['patch'].Value
+            $build = [int]$versionMatch.Groups['build'].Value
+
+            if ($major -eq 0 -and $minor -eq 0 -and $patch -eq 1) {
+                $packageType = "Preview Dev (Build #$build)"
+            } elseif ($patch -eq 0) {
+                $packageType = "Preview RC / Initial Archive (Build #$build)"
+            } else {
+                $packageType = "Preview Finalized Archive ($major.$minor.$patch, Build #$build)"
+            }
         } else {
-            $packageType = "Preview Dev (Build #$revision)"
+            $packageType = "Preview"
         }
     }
 
@@ -209,7 +219,11 @@ if ($ghAvailable) {
         }
 
         if ($coreVersion) {
-            Write-Host "  Store Hint   : run Release Finalize from release/X.Y with explicit patch=$(($coreVersion.Split('.'))[2]) (latest successful RC candidate is adopted automatically)" -ForegroundColor Cyan
+            if ($currentBranch -and $currentBranch -match '^release/\d+\.\d+$') {
+                Write-Host "  Store Hint   : run Release Finalize from $currentBranch with explicit patch=Z (the release branch stays $coreVersion and the selected archive/store package becomes X.Y.Z.B)" -ForegroundColor Cyan
+            } else {
+                Write-Host "  Store Hint   : run Release Finalize from release/X.Y with explicit patch=Z (release branches stay X.Y.0 and the selected archive/store package becomes X.Y.Z.B)" -ForegroundColor Cyan
+            }
             if ($resolvedReleaseTag) {
                 Write-Host "                 Candidate channel tag: $resolvedReleaseTag (adopt the intended RC build into the finalized archive)" -ForegroundColor Gray
             }
@@ -228,6 +242,7 @@ if ($currentBranch) {
 
     if ($currentBranch -match '^release/') {
         Write-Host "  Type    : Release branch" -ForegroundColor Green
+        Write-Host "  Policy  : repository version stays X.Y.0; Release Finalize chooses patch Z" -ForegroundColor Gray
     } elseif ($currentBranch -eq 'main') {
         Write-Host "  Type    : Main branch (trunk)" -ForegroundColor Cyan
     } else {

--- a/scripts/store-checklist.ps1
+++ b/scripts/store-checklist.ps1
@@ -125,6 +125,7 @@ try {
     }
 
     $versionSeries = "release/$($matches['major']).$($matches['minor'])"
+    $branchBaseVersion = "$($matches['major']).$($matches['minor']).0"
 
     $targetReleaseBranch = $ReleaseBranch
     if ($targetReleaseBranch) {
@@ -160,8 +161,13 @@ try {
     Write-Host "=== Microsoft Store Deployment Checklist ===" -ForegroundColor Green
     Write-Host "Target Version : $targetVersion" -ForegroundColor Cyan
     Write-Host "Target Branch  : $targetReleaseBranch" -ForegroundColor Cyan
+    Write-Host "RC Base Version: $branchBaseVersion" -ForegroundColor Cyan
     Write-Host "Working Branch : $currentBranch" -ForegroundColor Cyan
     Write-Host "Working Version: $workingVersion`n" -ForegroundColor Cyan
+    if (-not $versionSpecified -and $targetVersion -eq $branchBaseVersion) {
+        Write-Warning "release/X.Y keeps repository version X.Y.0. For patch releases beyond the initial X.Y.0 line, rerun this checklist with -Version X.Y.Z."
+        Write-Host ""
+    }
 
     $allPassed = $true
     $ghAvailable = Get-Command gh -ErrorAction SilentlyContinue
@@ -293,7 +299,7 @@ try {
             Write-Host "    Could not resolve GitHub repository from remote.origin.url." -ForegroundColor Gray
             $allPassed = $false
         } else {
-            $candidateArtifactName = "rc-package-$targetVersion"
+            $candidateArtifactName = "rc-package-$branchBaseVersion"
             $missingArtifacts = @()
             $queryFailed = $false
 
@@ -438,7 +444,7 @@ try {
     Write-Host "Please confirm the following items:`n"
 
     $checklist = @(
-        "RC package artifact (rc-package-$targetVersion, unsigned) reviewed for at least 24 hours",
+        "Selected RC candidate build (artifact family rc-package-$branchBaseVersion, unsigned) reviewed for at least 24 hours",
         "Confirmed tag X.Y.Z (=$targetVersion) created and pushed",
         "Release archive GitHub Release X.Y.Z (=$targetVersion) published by Release Finalize",
         "No critical bugs reported",
@@ -466,7 +472,7 @@ try {
 
     if ($allPassed -and $allManualPassed) {
         Write-Host "All checks passed. Ready for Store submission." -ForegroundColor Green
-        Write-Host "`nNext step: Run Release Finalize from $targetReleaseBranch with patch=$(($targetVersion.Split('.'))[2]) (latest successful RC candidate is adopted automatically)" -ForegroundColor Cyan
+        Write-Host "`nNext step: Run Release Finalize from $targetReleaseBranch with explicit patch=$(($targetVersion.Split('.'))[2]) (the release branch stays $branchBaseVersion and the latest successful RC candidate is adopted automatically)" -ForegroundColor Cyan
         exit 0
     } else {
         Write-Host "Some checks did not pass:" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- change release versioning so `release/X.Y` stays on repository version `X.Y.0` and `Release Finalize` alone decides finalized patch line `X.Y.Z`
- update release workflows and local scripts to treat RC packages as `X.Y.0.B` and finalized archive/store packages as `X.Y.Z.B`
- refresh release/store docs to describe only the current operating model and remove obsolete wording

## Verification
- `pwsh -NoProfile -File scripts/assert-version-policy.ps1 -BranchName main`
- `pwsh -NoProfile -File scripts/run-tests.ps1 -Configuration Release -Verbosity quiet`
- `pwsh -NoProfile -File scripts/run-security-checks.ps1 -Configuration Release -NoRestore`
