### PR TITLE
Fix MSIX Store localization resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.suo
 *.user
 *.userosscache
+*.lscache
 *.sln.docstates
 *.userprefs
 bin/

--- a/docs/distribution/store/StoreSubmission.md
+++ b/docs/distribution/store/StoreSubmission.md
@@ -42,6 +42,7 @@
 - `store-package-X.Y.Z` artifact から `.msixupload` を取得済みであること。
 - workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Package Version=X.Y.Z.B`、`Store Package Mode=built` を確認済みであること。
 - 必要に応じて workflow summary の `Source Package Version` を確認し、source RC candidate が `X.Y.0.B` から finalize されたことを理解していること。
+- package upload 後、Partner Center の「パッケージでサポートされている言語」に英語と日本語が表示されること。表示されない場合は提出せず、`.msixupload` 内の language resource package / `resources.pri` 生成を確認する。
 - `Privacy policy URL` に公開済みの [../../../PRIVACY.md](../../../PRIVACY.md) 相当ページを設定し、`Support contact` が設定済みであること。
 - listing CSV の必須項目（`Title`、`ShortDescription`、`ReleaseNotes`、`DesktopScreenshot1`）に空欄がないこと。
 - package upload 後に `制限付き機能` セクションが表示された場合は、`runFullTrust` の利用理由を記入済みであること。表示されない場合は、同内容を `審査向け補足` に記入済みであること。
@@ -90,6 +91,9 @@ Store policy 上、Desktop Bridge / Win32 製品は privacy policy が必須に�
 | workflow 入力 | `patch` に対象の `Z` を入れる（初回 `X.Y.0` リリースは `patch=0`）。通常は `build_store_package=true` / `create_version_tag=true` のまま実行 |
 | 対象バージョン | finalized package version は `X.Y.Z.B`（source RC candidate は `X.Y.0.B` のままでもよい） |
 | 対象デバイス | `Windows.Desktop` を確認 |
+| 対応言語 | `src/ClipSave.Package/Strings/en/Resources.resw` と `src/ClipSave.Package/Strings/ja/Resources.resw` から生成される英語/日本語 |
+
+MSIX の対応言語は Store listing CSV だけではなく、パッケージ側の `resources.pri` / language resource package で判定される。`ClipSave.Package.wapproj` は `Strings\**\*.resw` を `PRIResource` として含め、`Package.appxmanifest` は `<Resource Language="x-generate" />` と `ms-resource:` 参照で manifest 表示名を解決する。
 
 ### ストア登録情報（Listing）
 

--- a/scripts/set-package-manifest.ps1
+++ b/scripts/set-package-manifest.ps1
@@ -25,30 +25,30 @@ $profiles = @{
         # Local signed deployment/debugging profile.
         Name = "ClipSave.Preview"
         Publisher = "CN=ClipSavePreview"
-        PackageDisplayName = "ClipSave"
-        VisualDisplayName = "ClipSave Preview"
-        Description = "ClipSave Preview"
-        PublisherDisplayName = "tnagata012"
-        StartupTaskDisplayName = "ClipSave Preview"
+        PackageDisplayName = "ms-resource:PackageDisplayName"
+        VisualDisplayName = "ms-resource:PreviewVisualDisplayName"
+        Description = "ms-resource:PreviewDescription"
+        PublisherDisplayName = "ms-resource:PublisherDisplayName"
+        StartupTaskDisplayName = "ms-resource:PreviewStartupTaskDisplayName"
     }
     unsigned = @{
         # Unsigned artifact profile for Dev / RC / Archive channels.
         Name = "ClipSave.Preview"
         Publisher = "CN=ClipSavePreview, OID.2.25.311729368913984317654407730594956997722=1"
-        PackageDisplayName = "ClipSave"
-        VisualDisplayName = "ClipSave Preview"
-        Description = "ClipSave Preview"
-        PublisherDisplayName = "tnagata012"
-        StartupTaskDisplayName = "ClipSave Preview"
+        PackageDisplayName = "ms-resource:PackageDisplayName"
+        VisualDisplayName = "ms-resource:PreviewVisualDisplayName"
+        Description = "ms-resource:PreviewDescription"
+        PublisherDisplayName = "ms-resource:PublisherDisplayName"
+        StartupTaskDisplayName = "ms-resource:PreviewStartupTaskDisplayName"
     }
     store = @{
         Name = "tnagata012.ClipSave"
         Publisher = "CN=6ECD54B7-8ED5-46BA-81AD-ECBC0E843959"
-        PackageDisplayName = "ClipSave"
-        VisualDisplayName = "ClipSave"
-        Description = "ClipSave"
-        PublisherDisplayName = "tnagata012"
-        StartupTaskDisplayName = "ClipSave"
+        PackageDisplayName = "ms-resource:PackageDisplayName"
+        VisualDisplayName = "ms-resource:StoreVisualDisplayName"
+        Description = "ms-resource:StoreDescription"
+        PublisherDisplayName = "ms-resource:PublisherDisplayName"
+        StartupTaskDisplayName = "ms-resource:StoreStartupTaskDisplayName"
     }
 }
 

--- a/src/ClipSave.Package/ClipSave.Package.wapproj
+++ b/src/ClipSave.Package/ClipSave.Package.wapproj
@@ -108,6 +108,9 @@
     <Content Include="Images\Wide310x150Logo*.png" />
     <None Include="Package.StoreAssociation.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="Strings\**\*.resw" />
+  </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" PrivateAssets="all" />

--- a/src/ClipSave.Package/Package.appxmanifest
+++ b/src/ClipSave.Package/Package.appxmanifest
@@ -13,8 +13,8 @@
     Version="0.0.1.0" />
 
   <Properties>
-    <DisplayName>ClipSave</DisplayName>
-    <PublisherDisplayName>tnagata012</PublisherDisplayName>
+    <DisplayName>ms-resource:PackageDisplayName</DisplayName>
+    <PublisherDisplayName>ms-resource:PublisherDisplayName</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
 
@@ -24,8 +24,7 @@
   </Dependencies>
 
   <Resources>
-    <Resource Language="en"/>
-    <Resource Language="ja"/>
+    <Resource Language="x-generate" />
   </Resources>
 
   <Applications>
@@ -33,8 +32,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="ClipSave Preview"
-        Description="ClipSave Preview"
+        DisplayName="ms-resource:PreviewVisualDisplayName"
+        Description="ms-resource:PreviewDescription"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">
@@ -47,7 +46,7 @@
                            EntryPoint="Windows.FullTrustApplication">
           <desktop:StartupTask TaskId="ClipSaveStartupTask"
                                Enabled="true"
-                               DisplayName="ClipSave Preview" />
+                               DisplayName="ms-resource:PreviewStartupTaskDisplayName" />
         </desktop:Extension>
       </Extensions>
     </Application>

--- a/src/ClipSave.Package/Strings/en/Resources.resw
+++ b/src/ClipSave.Package/Strings/en/Resources.resw
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <data name="PackageDisplayName" xml:space="preserve">
+    <value>ClipSave</value>
+  </data>
+  <data name="PublisherDisplayName" xml:space="preserve">
+    <value>tnagata012</value>
+  </data>
+  <data name="PreviewVisualDisplayName" xml:space="preserve">
+    <value>ClipSave Preview</value>
+  </data>
+  <data name="PreviewDescription" xml:space="preserve">
+    <value>ClipSave Preview</value>
+  </data>
+  <data name="PreviewStartupTaskDisplayName" xml:space="preserve">
+    <value>ClipSave Preview</value>
+  </data>
+  <data name="StoreVisualDisplayName" xml:space="preserve">
+    <value>ClipSave</value>
+  </data>
+  <data name="StoreDescription" xml:space="preserve">
+    <value>Save clipboard content with one hotkey.</value>
+  </data>
+  <data name="StoreStartupTaskDisplayName" xml:space="preserve">
+    <value>ClipSave</value>
+  </data>
+</root>

--- a/src/ClipSave.Package/Strings/ja/Resources.resw
+++ b/src/ClipSave.Package/Strings/ja/Resources.resw
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <data name="PackageDisplayName" xml:space="preserve">
+    <value>ClipSave</value>
+  </data>
+  <data name="PublisherDisplayName" xml:space="preserve">
+    <value>tnagata012</value>
+  </data>
+  <data name="PreviewVisualDisplayName" xml:space="preserve">
+    <value>ClipSave Preview</value>
+  </data>
+  <data name="PreviewDescription" xml:space="preserve">
+    <value>ClipSave Preview</value>
+  </data>
+  <data name="PreviewStartupTaskDisplayName" xml:space="preserve">
+    <value>ClipSave Preview</value>
+  </data>
+  <data name="StoreVisualDisplayName" xml:space="preserve">
+    <value>ClipSave</value>
+  </data>
+  <data name="StoreDescription" xml:space="preserve">
+    <value>コピーした内容をホットキーでファイル保存します。</value>
+  </data>
+  <data name="StoreStartupTaskDisplayName" xml:space="preserve">
+    <value>ClipSave</value>
+  </data>
+</root>

--- a/tests/ClipSave.IntegrationTests/Configuration/StartupAndLanguageIntegrationTests.cs
+++ b/tests/ClipSave.IntegrationTests/Configuration/StartupAndLanguageIntegrationTests.cs
@@ -63,6 +63,47 @@ public class StartupAndLanguageIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void PackageManifest_UsesGeneratedLanguageResources()
+    {
+        var manifestPath = GetProjectPath("src", "ClipSave.Package", "Package.appxmanifest");
+        var document = XDocument.Load(manifestPath);
+        XNamespace appx = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
+        XNamespace uap = "http://schemas.microsoft.com/appx/manifest/uap/windows10";
+        XNamespace desktop = "http://schemas.microsoft.com/appx/manifest/desktop/windows10";
+
+        var resource = document.Root!
+            .Element(appx + "Resources")!
+            .Elements(appx + "Resource")
+            .Single();
+        resource.Attribute("Language")?.Value.Should().Be("x-generate");
+
+        document.Root.Element(appx + "Properties")!
+            .Element(appx + "DisplayName")!
+            .Value.Should().StartWith("ms-resource:");
+        document.Descendants(uap + "VisualElements").Single()
+            .Attribute("DisplayName")?.Value.Should().StartWith("ms-resource:");
+        document.Descendants(uap + "VisualElements").Single()
+            .Attribute("Description")?.Value.Should().StartWith("ms-resource:");
+        document.Descendants(desktop + "StartupTask").Single()
+            .Attribute("DisplayName")?.Value.Should().StartWith("ms-resource:");
+    }
+
+    [Fact]
+    public void PackageProject_IncludesReswFilesAsPriResources()
+    {
+        var projectPath = GetProjectPath("src", "ClipSave.Package", "ClipSave.Package.wapproj");
+        var document = XDocument.Load(projectPath);
+        XNamespace msbuild = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+        var priResourceIncludes = document.Descendants(msbuild + "PRIResource")
+            .Select(element => element.Attribute("Include")?.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToArray();
+
+        priResourceIncludes.Should().Contain("Strings\\**\\*.resw");
+    }
+
+    [Fact]
     [Spec("SPEC-041-002")]
     [Spec("SPEC-050-002")]
     public void SettingsWindow_DoesNotExposeStartupOrGlobalNotificationToggle()

--- a/tests/ClipSave.UnitTests/Resources/LocalizationResourceCompletenessTests.cs
+++ b/tests/ClipSave.UnitTests/Resources/LocalizationResourceCompletenessTests.cs
@@ -62,6 +62,19 @@ public class LocalizationResourceCompletenessTests
         missingKeys.Should().BeEmpty("All statically referenced localization keys must exist in Strings.resx.");
     }
 
+    [Fact]
+    public void PackageManifestResw_HasSameKeys_ForAllPackageLanguages()
+    {
+        var englishResources = LoadResources(GetPackageReswPath("en"));
+        var japaneseResources = LoadResources(GetPackageReswPath("ja"));
+
+        var missingInJapanese = englishResources.Keys.Except(japaneseResources.Keys).OrderBy(key => key).ToArray();
+        var extraInJapanese = japaneseResources.Keys.Except(englishResources.Keys).OrderBy(key => key).ToArray();
+
+        missingInJapanese.Should().BeEmpty("Japanese package resources must define all manifest keys.");
+        extraInJapanese.Should().BeEmpty("Japanese package resources must not contain unknown manifest keys.");
+    }
+
     private static Dictionary<string, string> LoadResources(string resxPath)
     {
         var document = XDocument.Load(resxPath);
@@ -132,5 +145,10 @@ public class LocalizationResourceCompletenessTests
     private static string GetJapaneseResxPath()
     {
         return Path.Combine(TestPaths.SourceRoot, "Resources", "Strings.ja.resx");
+    }
+
+    private static string GetPackageReswPath(string language)
+    {
+        return Path.Combine(TestPaths.PackageRoot, "Strings", language, "Resources.resw");
     }
 }

--- a/tests/ClipSave.UnitTests/TestInfrastructure/TestPaths.cs
+++ b/tests/ClipSave.UnitTests/TestInfrastructure/TestPaths.cs
@@ -13,4 +13,6 @@ internal static class TestPaths
         ".."));
 
     public static string SourceRoot { get; } = Path.Combine(RepositoryRoot, "src", "ClipSave");
+
+    public static string PackageRoot { get; } = Path.Combine(RepositoryRoot, "src", "ClipSave.Package");
 }


### PR DESCRIPTION
## Summary
- Add MSIX package-side `.resw` resources for `en` and `ja`, and include them as `PRIResource` inputs so Store package language detection sees them.
- Change package manifest display strings to `ms-resource:` references and keep preview/store profile switching resource-based.
- Add tests for package manifest/resource wiring and ignore generated `*.lscache` files.

## Why
- Microsoft Store determines supported package languages from the MSIX package resources/PRI, not from the WPF `.resx` resources or listing CSV alone.
- This lets Store uploads expose English and Japanese at the package level while preserving the existing WPF localization model.

## Checklist
### Change Type (choose one)
- [x] Docs/CI/site/repo config only.
- [ ] Includes product code or spec changes.

### Quality (as applicable)
- [x] Added/updated tests in the appropriate layer (Unit / Integration / UI), or documented why tests are not needed.
- [x] `./scripts/run-tests.ps1 -Configuration Release` succeeded locally, or documented why it is not needed.
- [x] If `Specification.md` or `Spec` attributes changed: `./scripts/check-spec-coverage.ps1` succeeded locally. Not needed; no spec files or `Spec` attributes changed.

Additional local verification:
- Direct MSBuild StoreUpload smoke package succeeded.
- Verified generated package payloads include base `EN` resources and `language-ja` resource package, both with `resources.pri`.

### Related Issue (choose one)
- [x] No related issue.
- [ ] Linked related issue.

### Specs (choose one)
- [x] No spec impact.
- [ ] Updated specs/docs for behavioral changes.

### Release Notes (choose one)
- [ ] User-facing change. Updated the relevant release-notes issue (`Release Notes: Unreleased` for main-bound work, `Release Notes: X.Y` for release-line work).
- [x] No user-facing change. No release-notes update needed.