### PR TITLE
Fix Store upload package version and publisher validation

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -667,6 +667,7 @@ jobs:
         $fileVersion = "$coreVersion.$build"
         $informationalVersion = "$coreVersion-build.$build+sha.$shortSha"
         $msixVersion = "$coreVersion.$build"
+        $storeMsixVersion = "$coreVersion.0"
 
         echo "VERSION=$version" >> $env:GITHUB_OUTPUT
         echo "BUILD=$build" >> $env:GITHUB_OUTPUT
@@ -675,11 +676,13 @@ jobs:
         echo "INFORMATIONAL_VERSION=$informationalVersion" >> $env:GITHUB_OUTPUT
         echo "COMMIT_SHA=$commitSha" >> $env:GITHUB_OUTPUT
         echo "MSIX_VERSION=$msixVersion" >> $env:GITHUB_OUTPUT
+        echo "STORE_MSIX_VERSION=$storeMsixVersion" >> $env:GITHUB_OUTPUT
         echo "Version: $version"
         echo "AssemblyVersion: $assemblyVersion"
         echo "FileVersion: $fileVersion"
         echo "InformationalVersion: $informationalVersion"
-        echo "MSIX version: $msixVersion"
+        echo "Archive MSIX version: $msixVersion"
+        echo "Store MSIX version: $storeMsixVersion"
 
     - name: Restore
       if: ${{ steps.archive_mode.outputs.SHOULD_BUILD_BINARIES == 'true' }}
@@ -871,7 +874,7 @@ jobs:
         | **Commit** | [`{7}`]({8}/{9}/commit/{7}) |
         | **Build** | [#{10}]({8}/{9}/actions/runs/{11}) |
 
-        > `release/X.Y` keeps repository version `X.Y.0`, so the selected RC candidate may expose source package version `X.Y.0.B` even when the finalized archive package becomes `X.Y.Z.B`.
+        > `release/X.Y` keeps repository version `X.Y.0`, so the selected RC candidate may expose source package version `X.Y.0.B` even when the finalized archive package becomes `X.Y.Z.B`. Store upload packages use identity version `X.Y.Z.0`.
         > Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` with the same `patch` adopts the latest successful RC candidate and may replace the selected build. After Store submission is recorded, the selected build is treated as fixed.
         '@ -f $version, $releaseBranch, $checkoutRef, "${{ steps.selected_source.outputs.SOURCE_PACKAGE_VERSION }}", $informationalVersion, $fileVersion, $msixVersion, $commitSha, $serverUrl, $repository, $runNumber, $runId
         }
@@ -943,7 +946,7 @@ jobs:
     - name: Prepare Store package manifest
       if: ${{ steps.target.outputs.BUILD_STORE_PACKAGE == 'true' }}
       shell: pwsh
-      run: ./tooling/scripts/set-package-manifest.ps1 -ProjectRoot "${{ github.workspace }}" -Profile store -Version "${{ steps.version.outputs.MSIX_VERSION }}"
+      run: ./tooling/scripts/set-package-manifest.ps1 -ProjectRoot "${{ github.workspace }}" -Profile store -Version "${{ steps.version.outputs.STORE_MSIX_VERSION }}"
 
     - name: Clean package intermediates before Store build
       if: ${{ steps.target.outputs.BUILD_STORE_PACKAGE == 'true' }}
@@ -969,9 +972,9 @@ jobs:
           /p:UapAppxPackageBuildMode=StoreUpload `
           /p:AppxBundle=Always `
           /p:AppxPackageDir="${{ github.workspace }}/StorePackage/" `
-          /p:AppxPackageVersion=${{ steps.version.outputs.MSIX_VERSION }} `
-          /p:AppxBundleManifestVersion=${{ steps.version.outputs.MSIX_VERSION }} `
-          /p:AppxManifestIdentityVersion=${{ steps.version.outputs.MSIX_VERSION }} `
+          /p:AppxPackageVersion=${{ steps.version.outputs.STORE_MSIX_VERSION }} `
+          /p:AppxBundleManifestVersion=${{ steps.version.outputs.STORE_MSIX_VERSION }} `
+          /p:AppxManifestIdentityVersion=${{ steps.version.outputs.STORE_MSIX_VERSION }} `
           /p:AppxPackageSigningEnabled=false
 
     - name: Validate Store package
@@ -979,7 +982,7 @@ jobs:
       shell: pwsh
       run: |
         $outputDir = "${{ github.workspace }}/StorePackage"
-        $expectedVersion = "${{ steps.version.outputs.MSIX_VERSION }}"
+        $expectedVersion = "${{ steps.version.outputs.STORE_MSIX_VERSION }}"
         $uploads = @(Get-ChildItem $outputDir -Recurse -File -Filter *.msixupload)
         if ($uploads.Count -eq 0) {
           throw "No .msixupload found under $outputDir"
@@ -999,7 +1002,8 @@ jobs:
           -PackagePath $upload.FullName `
           -ExpectedName "tnagata012.ClipSave" `
           -ExpectedPublisher "CN=6ECD54B7-8ED5-46BA-81AD-ECBC0E843959" `
-          -ExpectedVersion $expectedVersion
+          -ExpectedVersion $expectedVersion `
+          -ExpectedPublisherDisplayName "tnagata012"
 
         Write-Host "Store upload package validated: $($upload.Name)"
 
@@ -1083,7 +1087,8 @@ jobs:
         | Source Package Version | `{3}` |
         | InformationalVersion | `{4}` |
         | FileVersion | `{5}` |
-        | Package Version | `{6}` |
+        | Archive Package Version | `{6}` |
+        | Store Package Version | `{22}` |
         | Release Title | `{7}` |
         | Prerelease | `{8}` |
         | Release Notes | [`{9}`]({10}) |
@@ -1098,7 +1103,7 @@ jobs:
         | Commit SHA | `{17}` |
         | Build | [#{18}]({19}/{20}/actions/runs/{21}) |
 
-        `Release Notes` keeps a stable link to the release-line issue search, and `Operator Notes` / `Store Submission Log` are preserved across reruns. `release/X.Y` itself stays on repository version `X.Y.0`; `Release Finalize` alone rewrites the patch segment from the selected RC source package to the finalized archive/store package. Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` for the same `patch` adopts the latest successful RC candidate and can replace the selected archive build. After Store submission is recorded, the selected build is fixed.
+        `Release Notes` keeps a stable link to the release-line issue search, and `Operator Notes` / `Store Submission Log` are preserved across reruns. `release/X.Y` itself stays on repository version `X.Y.0`; `Release Finalize` rewrites the patch segment from the selected RC source package to archive package `X.Y.Z.B` and Store package `X.Y.Z.0`. Before Store submission is recorded, rerunning `Release Finalize` from `release/X.Y` for the same `patch` adopts the latest successful RC candidate and can replace the selected archive build. After Store submission is recorded, the selected build is fixed.
         '@ -f `
           "${{ steps.version.outputs.VERSION }}", `
           "${{ steps.source.outputs.RELEASE_BRANCH }}", `
@@ -1121,5 +1126,6 @@ jobs:
           "${{ github.run_number }}", `
           "${{ github.server_url }}", `
           "${{ github.repository }}", `
-          "${{ github.run_id }}"
+          "${{ github.run_id }}", `
+          "${{ steps.version.outputs.STORE_MSIX_VERSION }}"
         $summary >> $env:GITHUB_STEP_SUMMARY

--- a/docs/distribution/store/StoreSubmission.md
+++ b/docs/distribution/store/StoreSubmission.md
@@ -23,7 +23,7 @@
 
 - 対象版が [../../release/ReleaseProcess.md](../../release/ReleaseProcess.md) の Store チャネル進行条件を満たしている。
 - [../../release/ReleaseGuide.md](../../release/ReleaseGuide.md) に従って `Release Finalize` の Store package mode が成功している。
-- workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Package Version=X.Y.Z.B`、`Store Package Mode=built` を確認できる。
+- workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Archive Package Version=X.Y.Z.B`、`Store Package Version=X.Y.Z.0`、`Store Package Mode=built` を確認できる。
 - 必要に応じて workflow summary の `Source Package Version` を確認し、source RC candidate が `X.Y.0.B` から finalize されたことを理解している。
 - 同じ run の `store-package-X.Y.Z` artifact から `.msixupload` を取得でき、workflow の Store identity 検証も通っている。
 
@@ -40,8 +40,9 @@
 ## 提出前チェックリスト
 
 - `store-package-X.Y.Z` artifact から `.msixupload` を取得済みであること。
-- workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Package Version=X.Y.Z.B`、`Store Package Mode=built` を確認済みであること。
+- workflow summary で `Checkout Ref=refs/tags/X.Y.Z`、`Commit SHA`、`Archive Package Version=X.Y.Z.B`、`Store Package Version=X.Y.Z.0`、`Store Package Mode=built` を確認済みであること。
 - 必要に応じて workflow summary の `Source Package Version` を確認し、source RC candidate が `X.Y.0.B` から finalize されたことを理解していること。
+- `.msixupload` のファイル名と package upload 結果が Store package version `X.Y.Z.0` を示していること。
 - package upload 後、Partner Center の「パッケージでサポートされている言語」に英語と日本語が表示されること。表示されない場合は提出せず、`.msixupload` 内の language resource package / `resources.pri` 生成を確認する。
 - `Privacy policy URL` に公開済みの [../../../PRIVACY.md](../../../PRIVACY.md) 相当ページを設定し、`Support contact` が設定済みであること。
 - listing CSV の必須項目（`Title`、`ShortDescription`、`ReleaseNotes`、`DesktopScreenshot1`）に空欄がないこと。
@@ -89,11 +90,11 @@ Store policy 上、Desktop Bridge / Win32 製品は privacy policy が必須に�
 | 生成方法 | `.github/workflows/release-finalize.yml` |
 | workflow 実行 | GitHub Actions で `release/X.Y` を選択して実行 |
 | workflow 入力 | `patch` に対象の `Z` を入れる（初回 `X.Y.0` リリースは `patch=0`）。通常は `build_store_package=true` / `create_version_tag=true` のまま実行 |
-| 対象バージョン | finalized package version は `X.Y.Z.B`（source RC candidate は `X.Y.0.B` のままでもよい） |
+| 対象バージョン | version tag は `X.Y.Z`、Archive package version は `X.Y.Z.B`、Store MSIX identity version は `X.Y.Z.0`（source RC candidate は `X.Y.0.B` のままでもよい） |
 | 対象デバイス | `Windows.Desktop` を確認 |
 | 対応言語 | `src/ClipSave.Package/Strings/en/Resources.resw` と `src/ClipSave.Package/Strings/ja/Resources.resw` から生成される英語/日本語 |
 
-MSIX の対応言語は Store listing CSV だけではなく、パッケージ側の `resources.pri` / language resource package で判定される。`ClipSave.Package.wapproj` は `Strings\**\*.resw` を `PRIResource` として含め、`Package.appxmanifest` は `<Resource Language="x-generate" />` と `ms-resource:` 参照で manifest 表示名を解決する。
+MSIX の対応言語は Store listing CSV だけではなく、パッケージ側の `resources.pri` / language resource package で判定される。`ClipSave.Package.wapproj` は `Strings\**\*.resw` を `PRIResource` として含め、`Package.appxmanifest` は `<Resource Language="x-generate" />` と `ms-resource:` 参照で manifest 表示名を解決する。ただし Store profile の `PublisherDisplayName` は Partner Center が発行元表示名と直接照合するため、`ms-resource:` ではなく literal `tnagata012` を使う。
 
 ### ストア登録情報（Listing）
 

--- a/docs/release/ReleaseGuide.md
+++ b/docs/release/ReleaseGuide.md
@@ -27,7 +27,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 補足:
 
 - patch line `Z` は `Release Finalize` で決め、修正 PR は `release/X.Y` へ反映する。
-- Dev 配布版の package version は `0.0.1.B`、RC は `X.Y.0.B`、Archive / Store は `X.Y.Z.B` を使う。
+- Dev 配布版の package version は `0.0.1.B`、RC は `X.Y.0.B`、Archive は `X.Y.Z.B` を使う。Store upload package の MSIX identity version は Partner Center の制約に合わせて `X.Y.Z.0` とし、`FileVersion` / `InformationalVersion` で採用 build `B` を追跡する。
 - RC の `B` は `release/X.Y` branch ごとのカウンターで、新しい release branch を切ると 1 から始まる。
 - `main=0.0.1` を preview line として固定し、release branch の `X.Y.0` base version と finalized version line `X.Y.Z` を分けることで、Dev と RC / Archive / Store の役割を見分けやすくする。
 - `AssemblyVersion` は配布 build 識別子ではなく互換性用に扱い、実際の配布物識別は `FileVersion` / package version / `InformationalVersion` で行う。
@@ -51,7 +51,7 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 | Dev | `dev-latest` / `dev-package-*` + `SHA256SUMS.txt` | 検証配布（未署名、package version=`0.0.1.B`） |
 | RC | `rc-X.Y-latest` / `rc-package-*` + `SHA256SUMS.txt` | 公開候補比較（未署名、package version=`X.Y.0.B`） |
 | Archive | GitHub Release `X.Y.Z` / `release-archive-*` + `SHA256SUMS.txt` | 確定 build の固定配布 / 再検証（未署名、package version=`X.Y.Z.B`） |
-| Store | `store-package-*`（`.msixupload`） | Partner Center 提出 |
+| Store | `store-package-*`（`.msixupload`） | Partner Center 提出（MSIX identity version=`X.Y.Z.0`） |
 
 ## 実運用手順
 
@@ -86,12 +86,12 @@ Partner Center / listing の実務手順は [StoreSubmission](../distribution/st
 対象は [ReleaseProcess](ReleaseProcess.md) で定義した現行サポート系列のみとする。
 
 1. 不具合修正を `main` へ PR で反映する。
-2. `release/X.Y` をベースにした `fix/*` backport ブランチで必要コミットを `cherry-pick -x` し、PR で `release/X.Y` へ反映する。
+2. `release/X.Y` をベースにした `fix/*` 取り込みブランチで必要コミットを `cherry-pick -x` し、PR で `release/X.Y` へ反映する。
 3. `release/X.Y` の repository version は `X.Y.0` とする。
 4. `rc-X.Y-latest` と必要な RC 成果物を確認し、採用したい候補が latest RC として見えていることを確認する。
 5. `Release Finalize` 前に `Release Notes: X.Y` Issue を見直し、今回の patch 版として読めるよう公開向け文面を整える。
 6. `Release Finalize` を `release/X.Y` から実行し、operator が採番した対象 `patch=Z` を指定する。
-7. GitHub Release `X.Y.Z` に archive 成果物が保存され、workflow summary で source package version が `X.Y.0.B`、final package version が `X.Y.Z.B` になっていることを確認する。
+7. GitHub Release `X.Y.Z` に archive 成果物が保存され、workflow summary で source package version が `X.Y.0.B`、archive package version が `X.Y.Z.B`、Store package version が `X.Y.Z.0` になっていることを確認する。
 8. Store 提出前に追加修正が必要になった場合は、release branch を更新して RC Build を通し、同じ patch line `X.Y.Z` に対して `Release Finalize` を再実行する。
 9. Store へ進める条件を満たす場合のみ、Store package を生成して提出する。
 

--- a/docs/release/ReleaseNotes.md
+++ b/docs/release/ReleaseNotes.md
@@ -6,7 +6,7 @@
 
 1. `Release Notes: Unreleased` と `Release Notes: X.Y` に分けた方が、作業中ドラフトと release line ごとの公開ノートを分離しやすい。
 2. GitHub Release 本文は配布アーカイブの案内に寄せ、公開向け変更履歴の正本は issue 参照に寄せた方が運用が軽い。
-3. repo 内ファイルと GitHub Release 本文を二重更新すると、patch release や backport で転記漏れが起きやすい。
+3. repo 内ファイルと GitHub Release 本文を二重更新すると、patch release や release 取り込みで転記漏れが起きやすい。
 4. PR、release 準備、Store 前確認が同じ issue title を参照できる。
 
 ## 基本ルール
@@ -48,7 +48,7 @@ Issue title: `Release Notes: Unreleased`
 
 1. `main` 向けの user-facing PR は、`Release Notes: Unreleased` を更新する。
 2. `release/X.Y` 向けの user-facing PR は、当該 `Release Notes: X.Y` を更新する。
-3. `main` で user-facing change を入れ、その後 `release/X.Y` へ backport した場合は、release 側 PR で `Release Notes: X.Y` も更新する。
+3. `main` で user-facing change を入れ、その後 `release/X.Y` へ取り込んだ場合は、release 側 PR で `Release Notes: X.Y` も更新する。
 4. docs / CI / internal-only な PR は、release-notes issue を更新しない。
 5. PR テンプレの `Release Notes` チェックは、更新済みか不要かだけを示す。
 
@@ -68,7 +68,7 @@ Issue title: `Release Notes: Unreleased`
 ### release line 運用中
 
 1. `main` 側の user-facing change は `Release Notes: Unreleased` を更新する。
-2. `release/X.Y` 側の安定化 PR / backport PR は、必要に応じて `Release Notes: X.Y` を更新する。
+2. `release/X.Y` 側の安定化 PR / 取り込み PR は、必要に応じて `Release Notes: X.Y` を更新する。
 3. `Release Notes: X.Y` は、その系列で次に出す版の候補を保持する。
 
 ### Release Finalize 前
@@ -83,7 +83,7 @@ Issue title: `Release Notes: Unreleased`
 3. GitHub Release 本文には `Release Notes: X.Y` への参照が入る。
 4. issue が未整備のままでも release 自体は作成されるが、Store 前確認では未整備として扱う。
 5. Store 提出前に `Release Finalize` を `release/X.Y` から手動再実行する場合は、同じ patch line に対して対象の `patch=Z` を指定する。build は `rc-X.Y-latest` の最新成功候補から自動解決される。
-6. GitHub Release `X.Y.Z` は patch line を表し、selected RC source package は `X.Y.0.B` のままでも、archive / Store package は finalized version `X.Y.Z.B` に揃える。
+6. GitHub Release `X.Y.Z` は patch line を表し、selected RC source package は `X.Y.0.B` のままでも、archive package は `X.Y.Z.B`、Store package の MSIX identity は `X.Y.Z.0` に揃える。
 7. Store 提出後は `Store Submission Log` の記録をもって採用 commit が固定化されるため、再実行しても採用 build は勝手に差し替えない。
 8. issue 本文を更新しただけなら rerun は不要。再実行は GitHub Release 側の更新や archive 補完が必要な場合だけでよい。
 9. GitHub Release 本文は、配布案内を主としたシンプルな構成を保つ。

--- a/docs/release/ReleaseProcess.md
+++ b/docs/release/ReleaseProcess.md
@@ -30,10 +30,10 @@ flowchart LR
   main[main] -->|Dev Build| dev[dev-latest / dev-package-0.0.1.B]
   main -->|Prepare Release| release[release/X.Y]
   release -->|RC Build| rc[rc-X.Y-latest / rc-package-X.Y.0 / package X.Y.0.B]
-  release -->|stabilize/backport PR| release
+  release -->|stabilize/release PR| release
   release -->|Release Finalize patch=Z| tag[tag X.Y.Z]
   tag --> archive[GitHub Release X.Y.Z / release-archive-X.Y.Z.B]
-  tag --> store[store-package-X.Y.Z.B]
+  tag --> store[store-package-X.Y.Z / Store MSIX X.Y.Z.0]
 ```
 
 ## 基本モデル
@@ -41,12 +41,12 @@ flowchart LR
 1. 開発の正本は常に `main` とする。
 2. `main` の repository version は `0.0.1` とする。
 3. `release/X.Y` の repository version は常に `X.Y.0` とし、patch line `Z` は branch ではなく `Release Finalize` の手動入力で決める。
-4. 配布物の package / file version は 4 桁とし、4 桁目 `B` を build 番号として使う。
+4. Dev / RC / Archive の package version と全チャネルの file version は 4 桁とし、4 桁目 `B` を build 番号として使う。
 5. Dev の配布版は MSIX 都合のため予約済み preview line `0.0.1.B` を使う。
-6. RC の配布版は `X.Y.0.B`、Archive / Store の配布版は `X.Y.Z.B` を使い、`B` は `release/X.Y` ごとの `rc-build` カウンターを採用する。
+6. RC の配布版は `X.Y.0.B`、Archive の配布版は `X.Y.Z.B` を使い、`B` は `release/X.Y` ごとの `rc-build` カウンターを採用する。Store upload package の MSIX identity version は Partner Center の制約に合わせて `X.Y.Z.0` とし、`FileVersion` / `InformationalVersion` で `B` を追跡する。
 7. `release/X.Y` を新しく作ると、その branch の `B` は 1 から数え直す。
 8. version tag は `X.Y.Z` とし、GitHub Release `X.Y.Z` は patch line を表す。
-9. `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、`rc-X.Y-latest` の最新成功候補から `build=B` を採用して archive / Store package を揃える。
+9. `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、`rc-X.Y-latest` の最新成功候補から `build=B` を採用して archive と Store package を揃える。
 
 ## ブランチモデル
 
@@ -57,7 +57,7 @@ flowchart LR
 | `main` | 永続 | 次期開発の幹 |
 | `release/X.Y` | 中長期 | 公開安定化、現行系列サポート |
 | `feature/*` | 短命 | 機能追加 |
-| `fix/*` | 短命 | 不具合修正、backport |
+| `fix/*` | 短命 | 不具合修正、release 取り込み |
 | `docs/*` | 短命 | ドキュメント更新 |
 | `chore/*` | 短命 | 運用、自動化、雑務 |
 
@@ -70,17 +70,17 @@ flowchart LR
 ### 統合ルール
 
 1. 作業ブランチは `main` または対象 `release/X.Y` から作成し、PR で統合する。
-2. 修正の正本は常に `main` とし、release 側は必要分のみ backport する。
+2. 修正の正本は常に `main` とし、release 側は必要分のみ取り込む。
 3. `release/X.Y` から `main` へマージしない。
 4. `main` / `release/X.Y` への直 push は行わない。
 5. 緊急修正も `hotfix/*` ではなく、通常の patch release 手順で扱う。
 
-### backport 競合解消方針
+### release 取り込み競合解消方針
 
-1. `release/X.Y` から backport 用ブランチ（例: `fix/release-X.Y-backport-<id>`）を作成する。
+1. `release/X.Y` から取り込み用ブランチ（例: `fix/release-X.Y-<id>`）を作成する。
 2. `cherry-pick` の競合は release 系列の互換性を優先して解消する。
 3. 競合解消内容と理由を PR に明記する。
-4. release 側だけの場当たり修正を避け、必要なら `main` に先行調整を入れてから再 backport する。
+4. release 側だけの場当たり修正を避け、必要なら `main` に先行調整を入れてから再度 `release/X.Y` へ取り込む。
 
 ### GitHub での強制
 
@@ -106,14 +106,14 @@ flowchart LR
 ### 3. Finalize
 
 - 確定対象は、operator が選ぶ patch line `X.Y.Z` と、その時点の最新成功 RC build `X.Y.0.B` の組で決める。
-- `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、Store 提出前は `rc-X.Y-latest` の最新成功候補 `X.Y.0.B` を採用して tag / archive / Store package `X.Y.Z.B` を揃える。
+- `Release Finalize` は選択した `release/X.Y` と手動入力の `patch=Z` から `version=X.Y.Z` を解決し、Store 提出前は `rc-X.Y-latest` の最新成功候補 `X.Y.0.B` を採用して tag / archive package `X.Y.Z.B` / Store package `X.Y.Z.0` を揃える。
 - Store 提出前の手動再実行では、同じ patch line に対して `patch=Z` を指定し、その時点の最新成功 RC 候補を採用して archive / Store package を差し替えてよい。
 - Store 提出記録後は、その patch line の採用 commit を固定とする。
 
 ### 4. Distribute
 
 - Archive: GitHub Release `X.Y.Z` に、採用した最新成功 RC build を finalize した archive（`X.Y.Z.B`）を保持する。
-- Store: 一般ユーザー向けに出す版だけ、`Release Finalize` から Store package を生成する。
+- Store: 一般ユーザー向けに出す版だけ、`Release Finalize` から Store package を生成する。Store MSIX identity version は `X.Y.Z.0` とし、採用 build は `FileVersion` / `InformationalVersion` と workflow summary で確認する。
 - Store 公開の有無は finalized 判定に影響させないが、採用 commit 固定の境界は `Store Submission Log` 記録時点とする。
 
 ### 5. Support
@@ -138,7 +138,7 @@ flowchart LR
 ## Store チャネルへの進行条件
 
 1. Store 提出へ進めるのは、repository 全体の最新 finalized patch line で、かつ一般ユーザー向けに出す版のみとする。
-2. 対象の patch line は version tag `X.Y.Z` を正本とし、実際の package version は `X.Y.Z.B` とする。
+2. 対象の patch line は version tag `X.Y.Z` を正本とし、Archive package version は `X.Y.Z.B`、Store MSIX identity version は `X.Y.Z.0` とする。
 3. Store package の生成は `Release Finalize` から行う。
 4. Partner Center へ提出したら GitHub Release 本文の `Store Submission Log` に submission ID と commit を記録し、その時点で採用 commit を固定する。
 5. `store-package-*` を取得できた時点で、release 側の handoff 自体は完了としてよい。
@@ -159,19 +159,19 @@ flowchart LR
 | 文脈 | repository 上の版数 | 配布時の package / file version | 用途 |
 | ---- | ---- | ---- | ---- |
 | `main` | `0.0.1` | `0.0.1.B` | Dev preview line |
-| `release/X.Y` | `X.Y.0` | RC=`X.Y.0.B` / Archive, Store=`X.Y.Z.B` | 現行系列サポート |
+| `release/X.Y` | `X.Y.0` | RC=`X.Y.0.B` / Archive=`X.Y.Z.B` / Store MSIX=`X.Y.Z.0` | 現行系列サポート |
 
 補足:
 
 - `Directory.Build.props` の `Version` は repository 上では常に 3 桁とする。
 - `Package.appxmanifest` は repository 上では `Version.0` を保持する。
-- Dev / RC / Archive / Store の 4 桁目 `B` は CI / finalize 時に注入し、repository にはコミットしない。
+- Dev / RC / Archive の package version と全チャネルの file version の 4 桁目 `B` は CI / finalize 時に注入し、repository にはコミットしない。Store MSIX identity の 4 桁目は常に `0` にする。
 - RC の `B` は branch ごとのカウンターであり、`release/0.1` と `release/0.2` では独立して数える。
 
 なぜこの運用にするか:
 
 - `main` を `0.0.1` に固定するのは、Dev を常に preview line として識別し、安定化対象の `release/X.Y` が持つ `X.Y.0` base version や finalized version `X.Y.Z` と混同しないため。
-- Dev を `0.0.1.B`、RC を `X.Y.0.B`、Archive / Store を `X.Y.Z.B` に分けるのは、release branch の repository version を PR ごとに動かさず、Finalize だけが patch line を確定する責務分離にするため。
+- Dev を `0.0.1.B`、RC を `X.Y.0.B`、Archive を `X.Y.Z.B`、Store MSIX identity を `X.Y.Z.0` に分けるのは、release branch の repository version を PR ごとに動かさず、Finalize だけが patch line を確定する責務分離にするため。
 - `AssemblyVersion` は CLR の互換性軸として固定寄りに扱い、配布 build の識別責務は `FileVersion` / package version / `InformationalVersion` に寄せる。Dev で `0.0.0.0`、release 系で `X.Y.0.0` を使うのはこのため。
 
 ### タグ種別
@@ -192,7 +192,8 @@ flowchart LR
 | ---- | ---- | ---- |
 | Dev 配布物 | package / file version | `0.0.1.B` を使う |
 | RC 配布物 | package / file version | `X.Y.0.B` を使う |
-| Archive / Store 配布物 | package / file version | `X.Y.Z.B` を使う |
+| Archive 配布物 | package / file version | `X.Y.Z.B` を使う |
+| Store 配布物 | package identity / file version | MSIX identity は `X.Y.Z.0`、file version は `X.Y.Z.B` を使う |
 | 配布物 | 配布チャネル | `rc-X.Y-latest` は最新候補、GitHub Release `X.Y.Z` は patch line 用の archive 窓口 |
 
 ### 検証ルール
@@ -226,7 +227,7 @@ flowchart LR
 
 - patch release は現行サポート系列でのみ行う。
 - patch release 用 PR でも `release/X.Y` の repository version は `X.Y.0` のまま維持する。
-- 修正は `main` に入れてから必要分を `release/X.Y` へ backport し、version files は変えない。
+- 修正は `main` に入れてから必要分を `release/X.Y` へ取り込み、version files は変えない。
 - RC Build は常に branch base version `X.Y.0.B` を発行する。
 - `B` はその `release/X.Y` branch で継続し、新しい release branch を切るとリセットされる。
 - finalize では、operator が選ぶ `patch=Z` に対して、`rc-X.Y-latest` の最新成功候補を自動採用する。

--- a/scripts/assert-msixupload-identity.ps1
+++ b/scripts/assert-msixupload-identity.ps1
@@ -5,8 +5,8 @@
 
 .DESCRIPTION
     Opens a .msixupload, reads the bundled Appx bundle manifest and each
-    packaged app manifest, and verifies that Name / Publisher / Version match
-    the expected Store identity.
+    packaged app manifest, and verifies that Name / Publisher / Version /
+    PublisherDisplayName match the expected Store identity.
 #>
 
 param(
@@ -20,7 +20,10 @@ param(
     [string]$ExpectedPublisher,
 
     [Parameter(Mandatory = $true)]
-    [string]$ExpectedVersion
+    [string]$ExpectedVersion,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ExpectedPublisherDisplayName
 )
 
 $ErrorActionPreference = "Stop"
@@ -28,6 +31,10 @@ $ErrorActionPreference = "Stop"
 function Fail([string]$Message) {
     Write-Host "`n[ERROR] $Message" -ForegroundColor Red
     exit 1
+}
+
+if ($ExpectedVersion -notmatch '^\d+\.\d+\.\d+\.0$') {
+    Fail "Store upload package Version must use a zero revision segment (X.Y.Z.0). ExpectedVersion was '$ExpectedVersion'."
 }
 
 function Get-XmlFromZipEntry {
@@ -134,11 +141,14 @@ function Get-AppPackageIdentities {
                 throw "Package identity was not found in payload '$($packageEntry.FullName)'."
             }
 
+            $publisherDisplayNameNode = $manifest.SelectSingleNode("/appx:Package/appx:Properties/appx:PublisherDisplayName", $ns)
+
             $identities += [PSCustomObject]@{
-                Path      = $packageEntry.FullName
-                Name      = [string]$identity.Name
-                Publisher = [string]$identity.Publisher
-                Version   = [string]$identity.Version
+                Path                 = $packageEntry.FullName
+                Name                 = [string]$identity.Name
+                Publisher            = [string]$identity.Publisher
+                Version              = [string]$identity.Version
+                PublisherDisplayName = if ($publisherDisplayNameNode) { [string]$publisherDisplayNameNode.InnerText } else { "" }
             }
         }
         finally {
@@ -206,8 +216,23 @@ if ($payloadMismatch) {
     Fail "Payload identity mismatch detected. Expected Name='$ExpectedName', Publisher='$ExpectedPublisher', Version='$ExpectedVersion'. Actual: $($details -join '; ')"
 }
 
+if ($ExpectedPublisherDisplayName) {
+    $publisherDisplayNameMismatch = $payloadIdentities | Where-Object {
+        $_.PublisherDisplayName -ne $ExpectedPublisherDisplayName
+    }
+    if ($publisherDisplayNameMismatch) {
+        $details = $publisherDisplayNameMismatch | ForEach-Object {
+            "'$($_.Path)' => PublisherDisplayName='$($_.PublisherDisplayName)'"
+        }
+        Fail "Payload PublisherDisplayName mismatch detected. Expected '$ExpectedPublisherDisplayName'. Actual: $($details -join '; ')"
+    }
+}
+
 Write-Host "[OK] Store upload identity validated:" -ForegroundColor Green
 Write-Host "  Bundle Name      : $($bundleIdentity.Name)" -ForegroundColor White
 Write-Host "  Bundle Publisher : $($bundleIdentity.Publisher)" -ForegroundColor White
 Write-Host "  Bundle Version   : $($bundleIdentity.Version)" -ForegroundColor White
 Write-Host "  Payload Count    : $($payloadIdentities.Count)" -ForegroundColor White
+if ($ExpectedPublisherDisplayName) {
+    Write-Host "  Publisher Display Name : $ExpectedPublisherDisplayName" -ForegroundColor White
+}

--- a/scripts/build-store-package.ps1
+++ b/scripts/build-store-package.ps1
@@ -14,7 +14,9 @@
     release branch base version from Directory.Build.props (X.Y.0).
 
 .PARAMETER Build
-    Build number to append as the 4th segment (e.g., "57"). Defaults to 1 for local preflight.
+    Build number to use for file/informational versions (e.g., "57").
+    Store package identity always uses X.Y.Z.0 because Partner Center rejects
+    non-zero package revision segments.
 
 .EXAMPLE
     .\build-store-package.ps1
@@ -129,7 +131,6 @@ try {
     $assemblyVersion = "$($versionMatch.Groups['major'].Value).$($versionMatch.Groups['minor'].Value).0.0"
     $fileVersionValue = "$Version.$Build"
     $informationalVersion = "$Version-build.$Build+sha.$shortSha"
-    $msixVersion = "$Version.$Build"
 
     $tagsOnHead = @(
         git tag --points-at HEAD 2>$null |
@@ -143,6 +144,8 @@ try {
     Write-Host "Branch: $currentBranch" -ForegroundColor Cyan
     Write-Host "Release branch base version: $repositoryVersion" -ForegroundColor Cyan
     Write-Host "InformationalVersion: $informationalVersion" -ForegroundColor Cyan
+    Write-Host "FileVersion: $fileVersionValue" -ForegroundColor Cyan
+    Write-Host "Store package version: $Version.0" -ForegroundColor Cyan
     Write-Warning "This script is for local preflight only. Final submission packages must come from the Release Finalize workflow in Store package mode on the release branch."
     $msbuildPath = Resolve-MSBuildPath
     Write-Host "MSBuild: $msbuildPath" -ForegroundColor Cyan
@@ -203,7 +206,8 @@ try {
     Write-Host "`nPreparing Store Package.appxmanifest..." -ForegroundColor Yellow
     $manifestBackupPath = Join-Path ([System.IO.Path]::GetTempPath()) ("ClipSave.Package.appxmanifest.{0}.bak" -f [guid]::NewGuid())
     Copy-Item $manifestPath $manifestBackupPath -Force
-    & "$projectRoot\scripts\set-package-manifest.ps1" -ProjectRoot $projectRoot -Profile store -Version $msixVersion
+    $storeMsixVersion = "$Version.0"
+    & "$projectRoot\scripts\set-package-manifest.ps1" -ProjectRoot $projectRoot -Profile store -Version $storeMsixVersion
     Write-Host "Prepared Package.appxmanifest for Store profile" -ForegroundColor Cyan
 
     Write-Host "`nCleaning package intermediates..." -ForegroundColor Yellow
@@ -234,9 +238,9 @@ try {
         /p:UapAppxPackageBuildMode=StoreUpload `
         /p:AppxBundle=Always `
         /p:AppxPackageDir="$outputDir\" `
-        /p:AppxPackageVersion=$msixVersion `
-        /p:AppxBundleManifestVersion=$msixVersion `
-        /p:AppxManifestIdentityVersion=$msixVersion `
+        /p:AppxPackageVersion=$storeMsixVersion `
+        /p:AppxBundleManifestVersion=$storeMsixVersion `
+        /p:AppxManifestIdentityVersion=$storeMsixVersion `
         /p:AppxPackageSigningEnabled=false `
         /verbosity:minimal
 
@@ -258,9 +262,9 @@ try {
         exit 1
     }
     $msixUpload = $uploads[0]
-    $expectedPattern = "_$([regex]::Escape($msixVersion))_"
+    $expectedPattern = "_$([regex]::Escape($storeMsixVersion))_"
     if ($msixUpload.Name -notmatch $expectedPattern) {
-        Write-Error "Store upload filename does not contain expected version '$msixVersion'. Found: $($msixUpload.Name)"
+        Write-Error "Store upload filename does not contain expected version '$storeMsixVersion'. Found: $($msixUpload.Name)"
         exit 1
     }
 
@@ -268,7 +272,8 @@ try {
         -PackagePath $msixUpload.FullName `
         -ExpectedName "tnagata012.ClipSave" `
         -ExpectedPublisher "CN=6ECD54B7-8ED5-46BA-81AD-ECBC0E843959" `
-        -ExpectedVersion $msixVersion
+        -ExpectedVersion $storeMsixVersion `
+        -ExpectedPublisherDisplayName "tnagata012"
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Store package identity validation failed"
         exit 1
@@ -282,7 +287,7 @@ try {
     Write-Host "`n=== Next Steps ===" -ForegroundColor Green
     Write-Host "1. Use this local package only for preflight/debugging"
     Write-Host "2. For final submission, run Release Finalize from $currentBranch with explicit patch=$($versionMatch.Groups['patch'].Value) (the branch stays $repositoryVersion and the latest successful RC candidate is adopted automatically)"
-    Write-Host "3. Confirm workflow summary shows refs/tags/$Version, Package Version=$msixVersion, Store Package Mode=built, and the expected commit SHA"
+    Write-Host "3. Confirm workflow summary shows refs/tags/$Version, Store Package Version=$storeMsixVersion, Store Package Mode=built, and the expected commit SHA"
     Write-Host "4. Upload the workflow artifact .msixupload in Partner Center"
 
     Write-Host "`nTip: Run .\scripts\store-checklist.ps1 to verify pre-submission requirements" -ForegroundColor Yellow

--- a/scripts/set-package-manifest.ps1
+++ b/scripts/set-package-manifest.ps1
@@ -47,7 +47,7 @@ $profiles = @{
         PackageDisplayName = "ms-resource:PackageDisplayName"
         VisualDisplayName = "ms-resource:StoreVisualDisplayName"
         Description = "ms-resource:StoreDescription"
-        PublisherDisplayName = "ms-resource:PublisherDisplayName"
+        PublisherDisplayName = "tnagata012"
         StartupTaskDisplayName = "ms-resource:StoreStartupTaskDisplayName"
     }
 }

--- a/scripts/show-version-report.ps1
+++ b/scripts/show-version-report.ps1
@@ -220,9 +220,9 @@ if ($ghAvailable) {
 
         if ($coreVersion) {
             if ($currentBranch -and $currentBranch -match '^release/\d+\.\d+$') {
-                Write-Host "  Store Hint   : run Release Finalize from $currentBranch with explicit patch=Z (the release branch stays $coreVersion and the selected archive/store package becomes X.Y.Z.B)" -ForegroundColor Cyan
+                Write-Host "  Store Hint   : run Release Finalize from $currentBranch with explicit patch=Z (release branch stays $coreVersion; archive package becomes X.Y.Z.B; Store package becomes X.Y.Z.0)" -ForegroundColor Cyan
             } else {
-                Write-Host "  Store Hint   : run Release Finalize from release/X.Y with explicit patch=Z (release branches stay X.Y.0 and the selected archive/store package becomes X.Y.Z.B)" -ForegroundColor Cyan
+                Write-Host "  Store Hint   : run Release Finalize from release/X.Y with explicit patch=Z (release branches stay X.Y.0; archive package becomes X.Y.Z.B; Store package becomes X.Y.Z.0)" -ForegroundColor Cyan
             }
             if ($resolvedReleaseTag) {
                 Write-Host "                 Candidate channel tag: $resolvedReleaseTag (adopt the intended RC build into the finalized archive)" -ForegroundColor Gray

--- a/tests/ClipSave.IntegrationTests/Configuration/StartupAndLanguageIntegrationTests.cs
+++ b/tests/ClipSave.IntegrationTests/Configuration/StartupAndLanguageIntegrationTests.cs
@@ -4,6 +4,7 @@ using ClipSave.Services;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Windows.Threading;
@@ -101,6 +102,66 @@ public class StartupAndLanguageIntegrationTests : IDisposable
             .ToArray();
 
         priResourceIncludes.Should().Contain("Strings\\**\\*.resw");
+    }
+
+    [Fact]
+    public void SetPackageManifest_StoreProfile_UsesStoreSafePublisherAndRevision()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"ClipSave_ManifestProfile_{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(tempRoot, "src", "ClipSave.Package");
+        Directory.CreateDirectory(packageDirectory);
+
+        try
+        {
+            var manifestPath = Path.Combine(packageDirectory, "Package.appxmanifest");
+            File.Copy(GetProjectPath("src", "ClipSave.Package", "Package.appxmanifest"), manifestPath);
+
+            var scriptPath = GetProjectPath("scripts", "set-package-manifest.ps1");
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "pwsh",
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(scriptPath);
+            startInfo.ArgumentList.Add("-ProjectRoot");
+            startInfo.ArgumentList.Add(tempRoot);
+            startInfo.ArgumentList.Add("-Profile");
+            startInfo.ArgumentList.Add("store");
+            startInfo.ArgumentList.Add("-Version");
+            startInfo.ArgumentList.Add("0.1.1.0");
+
+            using var process = Process.Start(startInfo);
+            process.Should().NotBeNull();
+            var standardOutput = process!.StandardOutput.ReadToEnd();
+            var standardError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            process.ExitCode.Should().Be(0, "stdout: {0}; stderr: {1}", standardOutput, standardError);
+
+            var document = XDocument.Load(manifestPath);
+            XNamespace appx = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
+
+            document.Root!.Element(appx + "Properties")!
+                .Element(appx + "PublisherDisplayName")!
+                .Value.Should().Be("tnagata012");
+            document.Root.Element(appx + "Properties")!
+                .Element(appx + "DisplayName")!
+                .Value.Should().Be("ms-resource:PackageDisplayName");
+            document.Root.Element(appx + "Identity")!
+                .Attribute("Version")!
+                .Value.Should().Be("0.1.1.0");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Build Store upload packages with MSIX identity version `X.Y.Z.0` while keeping archive package/file traceability as `X.Y.Z.B`.
- Use literal `tnagata012` for Store `PublisherDisplayName` and validate it inside `.msixupload` payload packages.
- Update release/store documentation to distinguish RC source, archive package, and Store package versions.

## Verification
- `pwsh -NoProfile -File scripts/assert-version-policy.ps1 -BranchName main`
- `dotnet test tests/ClipSave.IntegrationTests/ClipSave.IntegrationTests.csproj --configuration Debug --filter "FullyQualifiedName~SetPackageManifest_StoreProfile_UsesStoreSafePublisherAndRevision"`
- PowerShell parser check for changed scripts
- `actionlint .github/workflows/release-finalize.yml`
- `git diff --check`
- `pwsh -NoProfile -File scripts/run-security-checks.ps1 -Configuration Release -NoRestore`
- `pwsh -NoProfile -File scripts/run-tests.ps1 -Configuration Release -Verbosity quiet`